### PR TITLE
Update OAuth Component group buttons to be all white instead of black.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig: NextConfig = {
   skipTrailingSlashRedirect: true,
   async rewrites() {
     return [
+      // Handle the /hebo redirect
+      {
+        source: "/hebo",
+        destination: "/",
+      },
       {
         source: "/ingest/static/:path*",
         destination: "https://eu-assets.i.posthog.com/static/:path*",

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,11 +6,6 @@ const nextConfig: NextConfig = {
   skipTrailingSlashRedirect: true,
   async rewrites() {
     return [
-      // Handle the /hebo redirect
-      {
-        source: "/hebo",
-        destination: "/",
-      },
       {
         source: "/ingest/static/:path*",
         destination: "https://eu-assets.i.posthog.com/static/:path*",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,24 +196,7 @@ input.stack-scope {
   margin: 0.5rem 0 !important;
 }
 
-/* OAuth Button Group Styles - Make all OAuth buttons white */
-.stack-scope [data-stack-oauth-button-group] button,
-.stack-scope [data-stack-oauth-button-group] a,
-.stack-scope [data-stack-oauth-button-group] div[role="button"] {
-  background-color: #ffffff !important;
-  color: #000000 !important;
-  border: 1px solid #e5e7eb !important;
-  transition: all 0.2s ease-in-out !important;
-}
-
-.stack-scope [data-stack-oauth-button-group] button:hover,
-.stack-scope [data-stack-oauth-button-group] a:hover,
-.stack-scope [data-stack-oauth-button-group] div[role="button"]:hover {
-  background-color: #f9fafb !important;
-  border-color: #d1d5db !important;
-}
-
-/* Alternative selectors for OAuth buttons in case the above don't work */
+/* Selectors for OAuth buttons in case the above don't work */
 .stack-scope button[data-provider],
 .stack-scope a[data-provider],
 .stack-scope div[data-provider] {
@@ -247,17 +230,6 @@ input.stack-scope {
   border-color: #d1d5db !important;
 }
 
-/* GitHub Icon Specific Styles - Make GitHub icons darker and more visible */
-.stack-scope [data-provider="github"] svg,
-.stack-scope [data-provider="github"] img,
-.stack-scope [class*="github"] svg,
-.stack-scope [class*="github"] img,
-.stack-scope [class*="GitHub"] svg,
-.stack-scope [class*="GitHub"] img {
-  filter: brightness(0) saturate(100%) !important;
-  color: #000000 !important;
-}
-
 /* Alternative selectors for GitHub icons */
 .stack-scope button[data-provider="github"] svg,
 .stack-scope a[data-provider="github"] svg,
@@ -265,22 +237,6 @@ input.stack-scope {
 .stack-scope button[data-provider="github"] img,
 .stack-scope a[data-provider="github"] img,
 .stack-scope div[data-provider="github"] img {
-  filter: brightness(0) saturate(100%) !important;
-  color: #000000 !important;
-}
-
-/* Target any element containing GitHub icon */
-.stack-scope svg[class*="github"],
-.stack-scope img[class*="github"],
-.stack-scope svg[class*="GitHub"],
-.stack-scope img[class*="GitHub"] {
-  filter: brightness(0) saturate(100%) !important;
-  color: #000000 !important;
-}
-
-/* Force dark color for any GitHub-related icon */
-.stack-scope [data-stack-oauth-button-group] svg,
-.stack-scope [data-stack-oauth-button-group] img {
   filter: brightness(0) saturate(100%) !important;
   color: #000000 !important;
 }
@@ -298,13 +254,6 @@ input.stack-scope {
   fill: #000000 !important;
 }
 
-/* Alternative approach - target any SVG path with white fill */
-.stack-scope svg path[fill="#FFFFFF"],
-.stack-scope svg path[fill="white"],
-.stack-scope svg path[fill="#fff"] {
-  fill: #000000 !important;
-}
-
 /* Dialog centering styles */
 .dialog {
   position: fixed;
@@ -318,4 +267,9 @@ input.stack-scope {
 /* Ensure dialog has border radius on all screen sizes */
 [role="dialog"] {
   border-radius: 1rem !important;
+}
+
+/* OTP digit box styling: force white background */
+.flex.items-center.gap-1 > .relative.flex.items-center.justify-center.border.rounded-md {
+  background-color: #fff !important;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,7 +196,7 @@ input.stack-scope {
   margin: 0.5rem 0 !important;
 }
 
-/* Selectors for OAuth buttons in case the above don't work */
+/* Selectors for OAuth buttons */
 .stack-scope button[data-provider],
 .stack-scope a[data-provider],
 .stack-scope div[data-provider] {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,6 +196,115 @@ input.stack-scope {
   margin: 0.5rem 0 !important;
 }
 
+/* OAuth Button Group Styles - Make all OAuth buttons white */
+.stack-scope [data-stack-oauth-button-group] button,
+.stack-scope [data-stack-oauth-button-group] a,
+.stack-scope [data-stack-oauth-button-group] div[role="button"] {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #e5e7eb !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.stack-scope [data-stack-oauth-button-group] button:hover,
+.stack-scope [data-stack-oauth-button-group] a:hover,
+.stack-scope [data-stack-oauth-button-group] div[role="button"]:hover {
+  background-color: #f9fafb !important;
+  border-color: #d1d5db !important;
+}
+
+/* Alternative selectors for OAuth buttons in case the above don't work */
+.stack-scope button[data-provider],
+.stack-scope a[data-provider],
+.stack-scope div[data-provider] {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #e5e7eb !important;
+}
+
+.stack-scope button[data-provider]:hover,
+.stack-scope a[data-provider]:hover,
+.stack-scope div[data-provider]:hover {
+  background-color: #f9fafb !important;
+  border-color: #d1d5db !important;
+}
+
+/* Additional selectors for OAuth buttons with different class patterns */
+.stack-scope .oauth-button,
+.stack-scope [class*="oauth"],
+.stack-scope [class*="OAuth"],
+.stack-scope [class*="provider"] {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+  border: 1px solid #e5e7eb !important;
+}
+
+.stack-scope .oauth-button:hover,
+.stack-scope [class*="oauth"]:hover,
+.stack-scope [class*="OAuth"]:hover,
+.stack-scope [class*="provider"]:hover {
+  background-color: #f9fafb !important;
+  border-color: #d1d5db !important;
+}
+
+/* GitHub Icon Specific Styles - Make GitHub icons darker and more visible */
+.stack-scope [data-provider="github"] svg,
+.stack-scope [data-provider="github"] img,
+.stack-scope [class*="github"] svg,
+.stack-scope [class*="github"] img,
+.stack-scope [class*="GitHub"] svg,
+.stack-scope [class*="GitHub"] img {
+  filter: brightness(0) saturate(100%) !important;
+  color: #000000 !important;
+}
+
+/* Alternative selectors for GitHub icons */
+.stack-scope button[data-provider="github"] svg,
+.stack-scope a[data-provider="github"] svg,
+.stack-scope div[data-provider="github"] svg,
+.stack-scope button[data-provider="github"] img,
+.stack-scope a[data-provider="github"] img,
+.stack-scope div[data-provider="github"] img {
+  filter: brightness(0) saturate(100%) !important;
+  color: #000000 !important;
+}
+
+/* Target any element containing GitHub icon */
+.stack-scope svg[class*="github"],
+.stack-scope img[class*="github"],
+.stack-scope svg[class*="GitHub"],
+.stack-scope img[class*="GitHub"] {
+  filter: brightness(0) saturate(100%) !important;
+  color: #000000 !important;
+}
+
+/* Force dark color for any GitHub-related icon */
+.stack-scope [data-stack-oauth-button-group] svg,
+.stack-scope [data-stack-oauth-button-group] img {
+  filter: brightness(0) saturate(100%) !important;
+  color: #000000 !important;
+}
+
+/* Specific GitHub SVG path styling - Change white fill to black */
+.stack-scope [data-provider="github"] svg path,
+.stack-scope [class*="github"] svg path,
+.stack-scope [class*="GitHub"] svg path,
+.stack-scope [data-stack-oauth-button-group] svg path {
+  fill: #000000 !important;
+}
+
+/* Target the specific GitHub logo SVG structure */
+.stack-scope svg[viewBox="0 0 496 512"] path {
+  fill: #000000 !important;
+}
+
+/* Alternative approach - target any SVG path with white fill */
+.stack-scope svg path[fill="#FFFFFF"],
+.stack-scope svg path[fill="white"],
+.stack-scope svg path[fill="#fff"] {
+  fill: #000000 !important;
+}
+
 /* Dialog centering styles */
 .dialog {
   position: fixed;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Introduced consistent white-themed styling for OAuth buttons, including smooth hover effects.
  - Enhanced visibility of GitHub icons by applying darker, more prominent styles.
  - Applied white backgrounds to OTP digit input boxes for improved clarity.
- **Chores**
  - Added a redirect rule to route `/hebo` requests to the homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->