### PR TITLE
add dev:hebo-cloud script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ pnpm run db:up
 pnpm run dev:sst
 ```
 
+```bash
+# Start only the hebo-cloud application
+pnpm run dev:hebo-cloud
+```
+
 ### Building
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "deploy": "turbo run deploy",
     "dev": "turbo run dev --parallel",
     "dev:sst": "sst dev",
+    "dev:hebo-cloud": "pnpm --filter @hebo/hebo-cloud dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy": "turbo run deploy",
     "dev": "turbo run dev --parallel",
     "dev:sst": "sst dev",
-    "dev:hebo-cloud": "pnpm --filter @hebo/hebo-cloud dev",
+    "dev:hebo-cloud": "pnpm --filter @hebo/hebo-cloud run dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test",


### PR DESCRIPTION
Added dev script command to locally launch hebo-cloud locally with no db.

 Dev (FE-only) (without db, no AI gateway)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new development command to run only the hebo-cloud application.

* **Documentation**
  * Updated the README to include instructions for starting just the hebo-cloud app during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->