### PR TITLE
Minimal schema factory with localized t.Omit use

### DIFF
--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -12,13 +12,10 @@ const { createInsertSchema, createUpdateSchema } = createSchemaFactory({
   typeboxInstance: t,
 });
 
-const OMIT_FIELDS = [...AUDIT_FIELDS, ...ID_FIELDS] as const;
-
 const _insertSchema = createInsertSchema(agents);
-const createAgent = createInsertSchema(agents, OMIT_FIELDS);
-const updateAgent = createUpdateSchema(agents, OMIT_FIELDS);
+const createAgent = createInsertSchema(agents);
+const updateAgent = createUpdateSchema(agents);
 
-// Ensure the path parameter type matches the corresponding database field type
 export const agentPathParam = t.Object({
   agentSlug: _insertSchema.properties.slug,
 });
@@ -34,7 +31,7 @@ export const agentRoutes = new Elysia({
       return "Not implemented" as const;
     },
     {
-      body: createAgent,
+      body: t.Omit(createAgent, [...AUDIT_FIELDS, ...ID_FIELDS]),
       response: { 501: t.String() },
     },
   )
@@ -67,7 +64,7 @@ export const agentRoutes = new Elysia({
     },
     {
       params: agentPathParam,
-      body: updateAgent,
+      body: t.Omit(updateAgent, [...AUDIT_FIELDS, ...ID_FIELDS]),
       response: { 501: t.String() },
     },
   )

--- a/apps/api/src/routes/branches.ts
+++ b/apps/api/src/routes/branches.ts
@@ -13,13 +13,10 @@ const { createInsertSchema, createUpdateSchema } = createSchemaFactory({
   typeboxInstance: t,
 });
 
-const OMIT_FIELDS = [...AUDIT_FIELDS, ...ID_FIELDS, "agentId"] as const;
-
 const _insertSchema = createInsertSchema(branches);
-const createBranch = createInsertSchema(branches, OMIT_FIELDS);
-const updateBranch = createUpdateSchema(branches, OMIT_FIELDS);
+const createBranch = createInsertSchema(branches);
+const updateBranch = createUpdateSchema(branches);
 
-// Ensure the path parameter types match the corresponding database field type
 const branchPathParams = t.Object({
   ...agentPathParam.properties,
   branchSlug: _insertSchema.properties.slug,
@@ -37,7 +34,7 @@ export const branchRoutes = new Elysia({
     },
     {
       params: agentPathParam,
-      body: createBranch,
+      body: t.Omit(createBranch, [...AUDIT_FIELDS, ...ID_FIELDS]),
       response: { 501: t.String() },
     },
   )
@@ -71,7 +68,7 @@ export const branchRoutes = new Elysia({
     },
     {
       params: branchPathParams,
-      body: updateBranch,
+      body: t.Omit(updateBranch, [...AUDIT_FIELDS, ...ID_FIELDS]),
       response: { 501: t.String() },
     },
   );

--- a/apps/api/src/routes/branches.ts
+++ b/apps/api/src/routes/branches.ts
@@ -34,7 +34,7 @@ export const branchRoutes = new Elysia({
     },
     {
       params: agentPathParam,
-      body: t.Omit(createBranch, [...AUDIT_FIELDS, ...ID_FIELDS]),
+      body: t.Omit(createBranch, [...AUDIT_FIELDS, ...ID_FIELDS, "agentSlug"]),
       response: { 501: t.String() },
     },
   )
@@ -68,7 +68,7 @@ export const branchRoutes = new Elysia({
     },
     {
       params: branchPathParams,
-      body: t.Omit(updateBranch, [...AUDIT_FIELDS, ...ID_FIELDS]),
+      body: t.Omit(updateBranch, [...AUDIT_FIELDS, ...ID_FIELDS, "agentSlug"]),
       response: { 501: t.String() },
     },
   );

--- a/apps/api/src/utils/schema-factory.ts
+++ b/apps/api/src/utils/schema-factory.ts
@@ -1,10 +1,4 @@
-import { Type } from "@sinclair/typebox";
-import {
-  createSchemaFactory as baseCreateSchemaFactory,
-  CreateSchemaFactoryOptions,
-} from "drizzle-typebox";
-
-import type { Table } from "drizzle-orm";
+export { createSchemaFactory } from "drizzle-typebox";
 
 export const AUDIT_FIELDS = [
   "createdBy",
@@ -16,29 +10,3 @@ export const AUDIT_FIELDS = [
 ] as const;
 
 export const ID_FIELDS = ["id", "slug"] as const;
-
-// TODO: We are breaking the type inference here. Fix this for the sake of consumers.
-export function createSchemaFactory(ops?: CreateSchemaFactoryOptions) {
-  const base = baseCreateSchemaFactory(ops);
-
-  const createSelectSchema = (entity: Table, keys?: readonly string[]) => {
-    const schema = base.createSelectSchema(entity);
-    return keys ? (ops?.typeboxInstance ?? Type).Omit(schema, keys) : schema;
-  };
-
-  const createInsertSchema = (entity: Table, keys?: readonly string[]) => {
-    const schema = base.createInsertSchema(entity);
-    return keys ? (ops?.typeboxInstance ?? Type).Omit(schema, keys) : schema;
-  };
-
-  const createUpdateSchema = (entity: Table, keys?: readonly string[]) => {
-    const schema = base.createUpdateSchema(entity);
-    return keys ? (ops?.typeboxInstance ?? Type).Omit(schema, keys) : schema;
-  };
-
-  return {
-    createSelectSchema,
-    createInsertSchema,
-    createUpdateSchema,
-  };
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Branch and Agent create/update endpoints now strictly ignore or reject system-managed fields (IDs/audit) in request bodies to prevent accidental overrides.
- Refactor
  - Internal schema handling simplified by using the upstream schema factory; no change to visible behavior aside from stricter request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->