### PR TITLE
HEB-94: Create ClickHouse Dockerfile and config with S3 store

### DIFF
--- a/infra/stacks/build-clickhouse/Dockerfile
+++ b/infra/stacks/build-clickhouse/Dockerfile
@@ -1,0 +1,3 @@
+FROM clickhouse/clickhouse-server:latest
+
+COPY --chown=clickhouse:clickhouse storage_config.xml /etc/clickhouse-server/config.d/storage_config.xml

--- a/infra/stacks/build-clickhouse/storage_config.xml
+++ b/infra/stacks/build-clickhouse/storage_config.xml
@@ -3,7 +3,7 @@
     <disks>
       <s3_disk>
         <type>s3</type>
-        <endpoint>https://tmp-hebo-clickhouse.s3.ap-southeast-5.amazonaws.com/</endpoint>
+        <endpoint from_env="S3_BUCKET"/>
         <use_environment_credentials>true</use_environment_credentials>
         <metadata_path>/var/lib/clickhouse/disks/s3_disk/</metadata_path>
       </s3_disk>
@@ -24,5 +24,8 @@
       </s3_main>
     </policies>
   </storage_configuration>
+  <merge_tree>
+    <storage_policy>s3_main</storage_policy>
+  </merge_tree>
   <postgresql_port>9005</postgresql_port>
 </clickhouse>

--- a/infra/stacks/build-clickhouse/storage_config.xml
+++ b/infra/stacks/build-clickhouse/storage_config.xml
@@ -1,0 +1,28 @@
+<clickhouse>
+  <storage_configuration>
+    <disks>
+      <s3_disk>
+        <type>s3</type>
+        <endpoint>https://tmp-hebo-clickhouse.s3.ap-southeast-5.amazonaws.com/</endpoint>
+        <use_environment_credentials>true</use_environment_credentials>
+        <metadata_path>/var/lib/clickhouse/disks/s3_disk/</metadata_path>
+      </s3_disk>
+      <s3_cache>
+        <type>cache</type>
+        <disk>s3_disk</disk>
+        <path>/var/lib/clickhouse/disks/s3_cache/</path>
+        <max_size>10Gi</max_size>
+      </s3_cache>
+    </disks>
+    <policies>
+      <s3_main>
+        <volumes>
+          <main>
+            <disk>s3_disk</disk>
+          </main>
+        </volumes>
+      </s3_main>
+    </policies>
+  </storage_configuration>
+  <postgresql_port>9005</postgresql_port>
+</clickhouse>


### PR DESCRIPTION
The following env vars are required to run the container:
- `CLICKHOUSE_DB`
- `CLICKHOUSE_USER`
- `CLICKHOUSE_PASSWORD`
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `S3_BUCKET`