### PR TITLE
Enable tools for streaming endpoint

### DIFF
--- a/apps/gateway/src/utils/converters.ts
+++ b/apps/gateway/src/utils/converters.ts
@@ -15,7 +15,7 @@ import {
   type OpenAICompatibleMessage,
   type OpenAICompatibleTool,
   type OpenAICompatibleToolChoice,
-  type OpenAICompatibleToolCallDelta, // Added this line
+  type OpenAICompatibleToolCallDelta,
 } from "./openai-compatible-api-schemas";
 
 function convertToModelContent(content: OpenAICompatibleContentPart[]) {

--- a/apps/gateway/src/utils/converters.ts
+++ b/apps/gateway/src/utils/converters.ts
@@ -183,7 +183,6 @@ export const toOpenAICompatibleMessage = (
   }
 
   if (result.reasoningText) {
-    message.reasoning = result.reasoningText; // GPT-OSS
     message.reasoning_content = result.reasoningText;
   }
 
@@ -262,7 +261,6 @@ export function toOpenAICompatibleStream(
 
           case "reasoning-delta": {
             const delta = {
-              reasoning: part.text,
               reasoning_content: part.text,
             };
             enqueue({

--- a/apps/gateway/src/utils/converters.ts
+++ b/apps/gateway/src/utils/converters.ts
@@ -4,6 +4,7 @@ import {
   type FinishReason,
   type GenerateTextResult,
   type ModelMessage,
+  type StreamTextResult,
   type ToolChoice,
 } from "ai";
 
@@ -14,6 +15,7 @@ import {
   type OpenAICompatibleMessage,
   type OpenAICompatibleTool,
   type OpenAICompatibleToolChoice,
+  type OpenAICompatibleToolCallDelta, // Added this line
 } from "./openai-compatible-api-schemas";
 
 function convertToModelContent(content: OpenAICompatibleContentPart[]) {
@@ -223,3 +225,163 @@ export const toToolChoice = (
     toolName: toolChoice.function.name,
   };
 };
+
+export function toOpenAICompatibleStream(
+  result: StreamTextResult<any, any>,
+  model: string,
+): ReadableStream<Uint8Array> {
+  const streamId = `chatcmpl-${crypto.randomUUID()}`;
+  const creationTime = Math.floor(Date.now() / 1000);
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    async start(controller) {
+      const enqueue = (data: object) => {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+      };
+
+      let toolCallIndexCounter = 0;
+
+      for await (const part of result.fullStream) {
+        switch (part.type) {
+          case "text-delta": {
+            const delta = {
+              role: "assistant",
+              content: part.text,
+            };
+            enqueue({
+              id: streamId,
+              object: "chat.completion.chunk",
+              created: creationTime,
+              model,
+              // eslint-disable-next-line unicorn/no-null
+              choices: [{ index: 0, delta, finish_reason: null }],
+            });
+            break;
+          }
+
+          case "reasoning-delta": {
+            const delta = {
+              reasoning: part.text,
+              reasoning_content: part.text,
+            };
+            enqueue({
+              id: streamId,
+              object: "chat.completion.chunk",
+              created: creationTime,
+              model,
+              // eslint-disable-next-line unicorn/no-null
+              choices: [{ index: 0, delta, finish_reason: null }],
+            });
+            break;
+          }
+
+          case "tool-call": {
+            const { toolCallId, toolName, input } = part;
+
+            const toolCall: OpenAICompatibleToolCallDelta = {
+              id: toolCallId,
+              index: toolCallIndexCounter++,
+              type: "function",
+              function: { name: toolName, arguments: JSON.stringify(input) },
+            };
+
+            enqueue({
+              id: streamId,
+              object: "chat.completion.chunk",
+              created: creationTime,
+              model,
+              choices: [
+                {
+                  index: 0,
+                  delta: { tool_calls: [toolCall] },
+                  // eslint-disable-next-line unicorn/no-null
+                  finish_reason: null,
+                },
+              ],
+            });
+            break;
+          }
+
+          case "finish": {
+            const { finishReason, totalUsage } = part;
+            enqueue({
+              id: streamId,
+              object: "chat.completion.chunk",
+              created: creationTime,
+              model,
+              choices: [
+                {
+                  index: 0,
+                  delta: {},
+                  finish_reason: toOpenAICompatibleFinishReason(finishReason),
+                },
+              ],
+              usage: totalUsage && {
+                prompt_tokens: totalUsage.inputTokens ?? 0,
+                completion_tokens: totalUsage.outputTokens ?? 0,
+                total_tokens:
+                  totalUsage.totalTokens ??
+                  (totalUsage.inputTokens ?? 0) +
+                    (totalUsage.outputTokens ?? 0),
+                completion_tokens_details: {
+                  reasoning_tokens: totalUsage.reasoningTokens ?? 0,
+                },
+                prompt_tokens_details: {
+                  cached_tokens: totalUsage.cachedInputTokens ?? 0,
+                },
+              },
+            });
+            break;
+          }
+
+          case "error": {
+            console.error(
+              "[toOpenAICompatibleStream] Stream error:",
+              part.error,
+            );
+            controller.close();
+            return;
+          }
+        }
+      }
+
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+}
+
+export function toOpenAICompatibleNonStreamResponse(
+  result: GenerateTextResult<any, any>,
+  model: string,
+) {
+  const finish_reason = toOpenAICompatibleFinishReason(result.finishReason);
+
+  return {
+    id: "chatcmpl-" + crypto.randomUUID(),
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: toOpenAICompatibleMessage(result),
+        finish_reason,
+      },
+    ],
+    usage: result.usage && {
+      prompt_tokens: result.usage.inputTokens ?? 0,
+      completion_tokens: result.usage.outputTokens ?? 0,
+      total_tokens:
+        result.usage.totalTokens ??
+        (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0),
+      completion_tokens_details: {
+        reasoning_tokens: result.usage.reasoningTokens ?? 0,
+      },
+      prompt_tokens_details: {
+        cached_tokens: result.usage.cachedInputTokens ?? 0,
+      },
+    },
+  };
+}

--- a/apps/gateway/src/utils/openai-compatible-api-schemas.ts
+++ b/apps/gateway/src/utils/openai-compatible-api-schemas.ts
@@ -116,3 +116,10 @@ export type OpenAICompatibleTool = Static<typeof OpenAICompatibleTool>;
 export type OpenAICompatibleToolChoice = Static<
   typeof OpenAICompatibleToolChoice
 >;
+
+export type OpenAICompatibleToolCallDelta = {
+  id: string;
+  index: number;
+  type: "function";
+  function: { name: string; arguments: string };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized completion responses so streaming and non-streaming outputs are consistently OpenAI-compatible, preserving finish reasons and usage details.

* **New Features**
  * Streaming now uses Server-Sent Events with keep-alive for more reliable live output.
  * Added incremental tool-call updates in streams so tool activity appears progressively.
  * Added a single-response OpenAI-compatible format for non-stream requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->