### PR TITLE
feat(console): migrate from valibot to zod v4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ bun run format       # Prettier formatting
 TypeScript + React drive the codebase. Trust Prettier and ESLint for formatting. Use PascalCase for components, camelCase for functions and variables, and kebab-case file names (e.g., `billing-summary.tsx`). Follow the Shadcn design system inside `packages/*-ui`, and keep Tailwind utility-first unless a pattern graduates into shared UI.
 
 ## Key Technologies & Use Cases
-ElysiaJS powers `apps/api` and `apps/gateway`; call helpers from `packages/shared-api` for auth, CORS, and typing. Console features run on React Router 7 (Framework mode) + Tailwind 4 (CSS) + ShadCN (Components) + Conform (Forms) + Valibot (Schema) + Valtio (Client State). Data access flows through `packages/database` (Prisma). SST manages infrastructure, so declare stacks in `infra/stacks` and ship secrets with `bun run sst secret set`.
+ElysiaJS powers `apps/api` and `apps/gateway`; call helpers from `packages/shared-api` for auth, CORS, and typing. Console features run on React Router 7 (Framework mode) + Tailwind 4 (CSS) + ShadCN (Components) + Conform (Forms) + Zod v4 (Schema) + Valtio (Client State). Data access flows through `packages/database` (Prisma). SST manages infrastructure, so declare stacks in `infra/stacks` and ship secrets with `bun run sst secret set`.
 
 Since we are using React Compiler, don't use useMemo, useCallback, and React.memo.
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -1,7 +1,7 @@
 import { Form, useActionData, useNavigation } from "react-router";
 import { useEffect, useRef, useState } from "react";
 import { useForm, getFormProps, type FieldMetadata } from "@conform-to/react";
-import { getValibotConstraint } from "@conform-to/valibot";
+import { getZodConstraint } from "@conform-to/zod/v4";
 import { Brain, Edit } from "lucide-react";
 
 import { Button } from "@hebo/shared-ui/components/Button";
@@ -62,7 +62,7 @@ export default function ModelsConfigForm({ agentSlug, branchSlug, models }: Mode
   const [form, fields] = useForm<ModelsConfigFormValues>({
     id: JSON.stringify(models),
     lastResult,
-    constraint: getValibotConstraint(modelsConfigFormSchema),
+    constraint: getZodConstraint(modelsConfigFormSchema),
     defaultValue: { models: models }
   });
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/route.tsx
@@ -1,5 +1,5 @@
 import { unstable_useRoute as useRoute } from "react-router";
-import { parseWithValibot } from "@conform-to/valibot";
+import { parseWithZod } from "@conform-to/zod/v4";
 
 import { api } from "~console/lib/service";
 import { parseError } from "~console/lib/errors";
@@ -12,7 +12,7 @@ import type { Route } from "./+types/route";
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
 
   const formData = await request.formData();
-  const submission = parseWithValibot(formData, {
+  const submission = parseWithZod(formData, {
     schema: modelsConfigFormSchema,
   });
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
@@ -4,11 +4,11 @@ import supportedModels from "@hebo/shared-data/json/supported-models";
 
 
 export const modelConfigSchema = z.object({
-  alias: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter a unique alias name"),
-  type: ((msg) => z
-    .string({ error: msg})
-    .refine((value) => supportedModels.some((model) => model.name === value), msg)
-    )("Select one of the supported models")
+  alias: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a unique alias name"),
+  type: z.literal(
+    supportedModels.map((model) => model.name),
+    "Select one of the supported models"
+  )
 });
 
 export const modelsConfigFormSchema = z.object({

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
@@ -1,34 +1,21 @@
-import {
-  array,
-  message,
-  nonEmpty,
-  object,
-  optional,
-  picklist,
-  pipe,
-  string,
-  trim,
-  type InferOutput,
-} from "valibot";
+import { z } from "zod";
 
 import supportedModels from "@hebo/shared-data/json/supported-models";
 
 
-export const modelConfigSchema = object({
-  alias: message(pipe(string(), trim(), nonEmpty()), "Please enter a unique alias name"),
-  type: picklist(
-    supportedModels.map((model) => model.name),
-    "Select one of the supported models",
-  )
+export const modelConfigSchema = z.object({
+  alias: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter a unique alias name"),
+  type: ((msg) => z
+    .string({ error: msg})
+    .refine((value) => supportedModels.some((model) => model.name === value), msg)
+    )("Select one of the supported models")
 });
 
-export const modelsConfigFormSchema = object({
-  models: pipe(
-    optional(array(modelConfigSchema)),
-  ),
+export const modelsConfigFormSchema = z.object({
+  models: z.array(modelConfigSchema).optional(),
 });
 
-export type ModelsConfigFormValues = InferOutput<typeof modelsConfigFormSchema>;
+export type ModelsConfigFormValues = z.infer<typeof modelsConfigFormSchema>;
 export type ModelConfigFormValue = NonNullable<ModelsConfigFormValues["models"]>[number];
 
 export { supportedModels };

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
@@ -1,10 +1,10 @@
 import { GitBranch } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Form, useActionData, useNavigation } from "react-router";
-import { message, nonEmpty, object, pipe, string, trim, type InferOutput } from "valibot";
+import { z } from "zod";
 
 import { getFormProps, useForm } from "@conform-to/react";
-import { getValibotConstraint } from "@conform-to/valibot";
+import { getZodConstraint } from "@conform-to/zod/v4";
 
 import { Button } from "@hebo/shared-ui/components/Button";
 import {
@@ -24,11 +24,11 @@ import { Select } from "@hebo/shared-ui/components/Select";
 import { useActionDataErrorToast } from "~console/lib/errors";
 
 
-export const BranchCreateSchema = object({
-  branchName: message(pipe(string(), trim(), nonEmpty()), "Please enter a branch name"),
-  sourceBranchSlug: string(),
+export const BranchCreateSchema = z.object({
+  branchName: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter a branch name"),
+  sourceBranchSlug: z.string(),
 });
-export type BranchCreateFormValues = InferOutput<typeof BranchCreateSchema>;
+export type BranchCreateFormValues = z.infer<typeof BranchCreateSchema>;
 
 
 type CreateBranchProps = {
@@ -47,7 +47,7 @@ export default function CreateBranch({ branches }: CreateBranchProps) {
 
   const [form, fields] = useForm<BranchCreateFormValues>({
     lastResult,
-    constraint: getValibotConstraint(BranchCreateSchema),
+    constraint: getZodConstraint(BranchCreateSchema),
     defaultValue: {
       sourceBranchSlug: branches[0].slug,
     },

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
@@ -25,7 +25,7 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 
 export const BranchCreateSchema = z.object({
-  branchName: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter a branch name"),
+  branchName: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a branch name"),
   sourceBranchSlug: z.string(),
 });
 export type BranchCreateFormValues = z.infer<typeof BranchCreateSchema>;

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 import { Form, useActionData, useNavigation } from "react-router";
-import { literal, object, type InferOutput } from "valibot";
+import { z } from "zod";
 
 import { getFormProps, useForm } from "@conform-to/react";
-import { getValibotConstraint } from "@conform-to/valibot";
+import { getZodConstraint } from "@conform-to/zod/v4";
 
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@hebo/shared-ui/components/Dialog";
 import { Alert, AlertTitle } from "@hebo/shared-ui/components/Alert";
@@ -15,11 +15,14 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 
 export function createBranchDeleteSchema(branchSlug: string) {
-  return object({
-    slugConfirm: literal(branchSlug, "You must type your EXACT branch slug"),
+  return z.object({
+    slugConfirm: ((msg) => z
+      .string({ error: msg })
+      .refine((value) => value === branchSlug, msg)
+    )("You must type your EXACT branch slug")
   });
 }
-export type BranchDeleteFormValues = InferOutput<ReturnType<typeof createBranchDeleteSchema>>;
+export type BranchDeleteFormValues = z.infer<ReturnType<typeof createBranchDeleteSchema>>;
 
 type DeleteBranchDialogProps = {
   open: boolean;
@@ -35,7 +38,7 @@ export default function DeleteBranchDialog({ open, onOpenChange, branchSlug }: D
   const [form, fields] = useForm<BranchDeleteFormValues>({
     lastResult,
     id: branchSlug,
-    constraint: getValibotConstraint(createBranchDeleteSchema(branchSlug)),
+    constraint: getZodConstraint(createBranchDeleteSchema(branchSlug)),
   });
 
   const navigation = useNavigation();

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
@@ -16,11 +16,8 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 export function createBranchDeleteSchema(branchSlug: string) {
   return z.object({
-    slugConfirm: ((msg) => z
-      .string({ error: msg })
-      .refine((value) => value === branchSlug, msg)
-    )("You must type your EXACT branch slug")
-  });
+    slugConfirm: z.literal(branchSlug, "You must type your EXACT branch slug")
+  })
 }
 export type BranchDeleteFormValues = z.infer<ReturnType<typeof createBranchDeleteSchema>>;
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/route.tsx
@@ -1,6 +1,6 @@
 import { unstable_useRoute as useRoute } from "react-router";
 
-import { parseWithValibot } from "@conform-to/valibot";
+import { parseWithZod } from "@conform-to/zod/v4";
 
 import CreateBranch, { BranchCreateSchema } from "./create";
 import { createBranchDeleteSchema } from "./delete";
@@ -19,7 +19,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs )
 
   switch (intent) {
     case "create":
-      submission = parseWithValibot(formData, {
+      submission = parseWithZod(formData, {
         schema: BranchCreateSchema
       });
 
@@ -45,7 +45,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs )
     case "delete": 
       const branchSlug = formData.get("branchSlug") as string;
 
-      submission = parseWithValibot(formData, {
+      submission = parseWithZod(formData, {
         schema: createBranchDeleteSchema(branchSlug)
       });
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/danger-zone.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/danger-zone.tsx
@@ -1,7 +1,7 @@
 import { Form, useActionData, useNavigation } from "react-router";
-import { object, literal, type InferOutput } from "valibot";
+import { z } from "zod";
 import { useForm, getFormProps } from "@conform-to/react";
-import { getValibotConstraint } from "@conform-to/valibot";
+import { getZodConstraint } from "@conform-to/zod/v4";
 
 import { Alert, AlertTitle } from "@hebo/shared-ui/components/Alert";
 import { Button } from "@hebo/shared-ui/components/Button";
@@ -34,11 +34,15 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 
 export function createAgentDeleteSchema(agentSlug: string) {
-  return object({
-    slugConfirm: literal(agentSlug, "You must type your EXACT agent slug"),
+  return z.object({
+    slugConfirm: ((msg) => z
+      .string({ error: msg })
+      .refine((value) => value === agentSlug, msg)
+    )("You must type your EXACT agent slug")
   });
 }
-export type AgentDeleteFormValues = InferOutput<ReturnType<typeof createAgentDeleteSchema>>;
+
+export type AgentDeleteFormValues = z.infer<ReturnType<typeof createAgentDeleteSchema>>;
 
 export function DangerSettings({ agent }: { agent: { slug: string }}) {
 
@@ -48,7 +52,7 @@ export function DangerSettings({ agent }: { agent: { slug: string }}) {
 
   const [form, fields] = useForm<AgentDeleteFormValues>({
     lastResult,
-    constraint: getValibotConstraint(createAgentDeleteSchema(agent.slug)),
+    constraint: getZodConstraint(createAgentDeleteSchema(agent.slug)),
   });
 
   const navigation = useNavigation();

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/danger-zone.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/danger-zone.tsx
@@ -35,10 +35,7 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 export function createAgentDeleteSchema(agentSlug: string) {
   return z.object({
-    slugConfirm: ((msg) => z
-      .string({ error: msg })
-      .refine((value) => value === agentSlug, msg)
-    )("You must type your EXACT agent slug")
+    slugConfirm: z.literal(agentSlug, "You must type your EXACT agent slug")
   });
 }
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
@@ -1,5 +1,5 @@
 import { redirect, unstable_useRoute as useRoute } from "react-router";
-import { parseWithValibot } from "@conform-to/valibot";
+import { parseWithZod } from "@conform-to/zod/v4";
 
 import { api } from "~console/lib/service";
 import { parseError } from "~console/lib/errors";
@@ -13,7 +13,7 @@ import { GeneralSettings } from "./general";
 export async function clientAction({ request, params }: Route.ClientActionArgs ) {
   const formData = await request.formData();
 
-  const submission = parseWithValibot(formData, {
+  const submission = parseWithZod(formData, {
      schema: createAgentDeleteSchema(params.agentSlug)
   });
   

--- a/apps/console/app/routes/_shell.agent.create/form.tsx
+++ b/apps/console/app/routes/_shell.agent.create/form.tsx
@@ -28,7 +28,7 @@ import { useActionDataErrorToast } from "~console/lib/errors";
 
 
 export const AgentCreateSchema = z.object({
-  agentName: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter an agent name"),
+  agentName: ((msg) => z.string(msg).trim().min(1, msg))("Please enter an agent name"),
   defaultModel: z.string(),
 });
 export type AgentCreateFormValues = z.infer<typeof AgentCreateSchema>;

--- a/apps/console/app/routes/_shell.agent.create/form.tsx
+++ b/apps/console/app/routes/_shell.agent.create/form.tsx
@@ -1,7 +1,7 @@
 import { Form, useActionData, useNavigation } from "react-router";
-import { message, nonEmpty, object, string, pipe, trim, type InferOutput } from "valibot";
+import { z } from "zod";
 import { useForm, getFormProps } from "@conform-to/react";
-import { getValibotConstraint } from "@conform-to/valibot";
+import { getZodConstraint } from "@conform-to/zod/v4";
 
 import supportedModels from "@hebo/shared-data/json/supported-models";
 import { Button } from "@hebo/shared-ui/components/Button";
@@ -27,11 +27,11 @@ import {
 import { useActionDataErrorToast } from "~console/lib/errors";
 
 
-export const AgentCreateSchema = object({
-  agentName: message(pipe(string(), trim(), nonEmpty()), "Please enter an agent name"),
-  defaultModel: string(),
+export const AgentCreateSchema = z.object({
+  agentName: ((msg) => z.string({ error: msg }).trim().min(1, msg))("Please enter an agent name"),
+  defaultModel: z.string(),
 });
-export type AgentCreateFormValues = InferOutput<typeof AgentCreateSchema>;
+export type AgentCreateFormValues = z.infer<typeof AgentCreateSchema>;
 
 export function AgentCreateForm() {
   const lastResult = useActionData();
@@ -40,7 +40,7 @@ export function AgentCreateForm() {
   
   const [form, fields] = useForm<AgentCreateFormValues>({
     lastResult,
-    constraint: getValibotConstraint(AgentCreateSchema),
+    constraint: getZodConstraint(AgentCreateSchema),
     defaultValue: {
       defaultModel: supportedModels[0].name,
     }

--- a/apps/console/app/routes/_shell.agent.create/route.tsx
+++ b/apps/console/app/routes/_shell.agent.create/route.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "react-router";
-import { parseWithValibot } from "@conform-to/valibot";
+import { parseWithZod } from "@conform-to/zod/v4";
 
 import { api } from "~console/lib/service";
 import { parseError } from "~console/lib/errors";
@@ -12,7 +12,7 @@ import { AgentCreateForm, AgentCreateSchema } from "./form";
 export async function clientAction({ request }: Route.ClientActionArgs ) {
   const formData = await request.formData();
 
-  const submission = parseWithValibot(formData, { schema: AgentCreateSchema });
+  const submission = parseWithZod(formData, { schema: AgentCreateSchema });
   
   if (submission.status !== 'success')
     return submission.reply();

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.29",
-    "@conform-to/react": "^1.9.0",
-    "@conform-to/valibot": "^1.9.0",
+    "@conform-to/react": "^1.13.3",
+    "@conform-to/zod": "^1.13.3",
     "@elysiajs/eden": "^1.4.3",
     "@hebo/aikit-ui": "workspace:*",
     "@hebo/shared-data": "workspace:*",
@@ -47,7 +47,6 @@
     "react-hotkeys-hook": "^5.1.0",
     "react-router": "^7.9.6",
     "sonner": "^2.0.7",
-    "valibot": "^1.1.0",
     "valtio": "^2.1.5",
     "zod": "^4.1.12"
   },

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@ai-sdk/groq": "^2.0.11",
     "@bogeychan/elysia-logger": "^0.1.10",
-    "@elysiajs/openapi": "^1.4.11",
     "@elysiajs/cors": "^1.4.0",
+    "@elysiajs/openapi": "^1.4.11",
     "@hebo/database": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@hebo/shared-data": "workspace:*",
@@ -28,7 +28,7 @@
     "elysia": "^1.4.9",
     "sst": "^3.17.13",
     "voyage-ai-provider": "^2.0.0",
-    "zod": "^4"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "bun-types": "^1.2.22",

--- a/bun.lock
+++ b/bun.lock
@@ -58,8 +58,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.29",
-        "@conform-to/react": "^1.9.0",
-        "@conform-to/valibot": "^1.9.0",
+        "@conform-to/react": "^1.13.3",
+        "@conform-to/zod": "^1.13.3",
         "@elysiajs/eden": "^1.4.3",
         "@hebo/aikit-ui": "workspace:*",
         "@hebo/shared-data": "workspace:*",
@@ -89,7 +89,6 @@
         "react-hotkeys-hook": "^5.1.0",
         "react-router": "^7.9.6",
         "sonner": "^2.0.7",
-        "valibot": "^1.1.0",
         "valtio": "^2.1.5",
         "zod": "^4.1.12",
       },
@@ -131,7 +130,7 @@
         "elysia": "^1.4.9",
         "sst": "^3.17.13",
         "voyage-ai-provider": "^2.0.0",
-        "zod": "^4",
+        "zod": "^4.1.12",
       },
       "devDependencies": {
         "bun-types": "^1.2.22",
@@ -399,11 +398,11 @@
 
     "@bogeychan/elysia-logger": ["@bogeychan/elysia-logger@0.1.10", "", { "peerDependencies": { "elysia": ">= 1.2.10", "pino": ">= 9.6.0" } }, "sha512-wFp3KUCNIkCV4zcbo70gifHH99ch7e4LNrP5Xa5e2MRO2MDyPgM92SWQmrzkng6PsSZk13+UKJskGNQ+ZuDZkQ=="],
 
-    "@conform-to/dom": ["@conform-to/dom@1.12.0", "", {}, "sha512-TKTic9bKm7uEuf3ntrs5VeD3iDeEpSnA5H2qnAfI9dbostEr2hNlXCjOEGKFBiBtx+aPjpHtt/e0rs0+t+vWxg=="],
+    "@conform-to/dom": ["@conform-to/dom@1.13.3", "", {}, "sha512-V4uNfUcx0cfuwnL/yNtjRvWxzwyNWhayBJXhRDBxEtiqBJiSEge6qeMN0xSUDbZezj5uAl13rzVQyf6FZXoOZQ=="],
 
-    "@conform-to/react": ["@conform-to/react@1.12.0", "", { "dependencies": { "@conform-to/dom": "1.12.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-V4JkXTzRBEE8RbwKf4MzVykJI/kv9wu70qbiWnFgdlYbC0oA27iIN/7aAYKbTRXvzkWtoe6fpi5vjV0I9ikb5g=="],
+    "@conform-to/react": ["@conform-to/react@1.13.3", "", { "dependencies": { "@conform-to/dom": "1.13.3" }, "peerDependencies": { "react": ">=18" } }, "sha512-3qLE52gLUKX9UBadto06mluqU+LS+S/oo/KXfCWJYhW2WxtZg87mG0c1kstPVBOOkocPzCCHN6Hjo4vwrGgiPg=="],
 
-    "@conform-to/valibot": ["@conform-to/valibot@1.12.0", "", { "dependencies": { "@conform-to/dom": "1.12.0" }, "peerDependencies": { "valibot": ">= 0.32.0" } }, "sha512-2pwHLStuqfz9cf87KuJhki4N9TIN93P4FD0m+n+iRSWtPtue8kopsHkxnUtGXVuQNVtaGbOSEQcCgv7FaRCDBQ=="],
+    "@conform-to/zod": ["@conform-to/zod@1.13.3", "", { "dependencies": { "@conform-to/dom": "1.13.3" }, "peerDependencies": { "zod": "^3.21.0 || ^4.0.0" } }, "sha512-HimtfcJPgjlhmMRWUvvyFvgdPgAmG/54qY/Bp1Wtoi+mRQ4ffBuBy+0L8mlc1USeI1X2YEZDfMurOlTf92xQwA=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched form validation across the console UI to Zod, standardizing client- and server-side parsing for branch, agent, model create/delete forms and related flows.
  * Updated project manifests to add Zod integration and remove the previous validation packages.

* **Documentation**
  * Updated documentation to reference Zod v4 for schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->