### PR TITLE
chores(gateway): remove support for old claude and haiku models

### DIFF
--- a/packages/shared-data/json/supported-models.json
+++ b/packages/shared-data/json/supported-models.json
@@ -46,28 +46,6 @@
     "modality": "chat"
   },
   {
-    "type": "anthropic/claude-sonnet-4-20250514-v1",
-    "displayName": "Anthropic Claude Sonnet 4",
-    "rateLimit": 400000000,
-    "providers": [
-      {
-        "bedrock": "anthropic.claude-sonnet-4-20250514-v1:0"
-      }
-    ],
-    "modality": "chat"
-  },
-  {
-    "type": "anthropic/claude-3-haiku-20240307-v1",
-    "displayName": "Anthropic Claude Haiku 3",
-    "rateLimit": 400000000,
-    "providers": [
-      {
-        "bedrock": "anthropic.claude-3-haiku-20240307-v1:0"
-      }
-    ],
-    "modality": "chat"
-  },
-  {
     "type": "cohere/embed-v4.0",
     "displayName": "Cohere Embed v4.0",
     "rateLimit": 400000000,


### PR DESCRIPTION
This solves [HEB-190](https://linear.app/heboai/issue/HEB-190/gateway-remove-support-for-outdated-claude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Claude Sonnet 4 and Claude Haiku 3 from the list of supported AI models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->