### PR TITLE
feat(gateway): include support for gemini 2.5 preview

### DIFF
--- a/packages/shared-data/json/supported-models.json
+++ b/packages/shared-data/json/supported-models.json
@@ -24,6 +24,17 @@
     "modality": "chat"
   },
   {
+    "type": "google/gemini-2.5-flash-preview-09-2025",
+    "displayName": "Gemini 2.5 Flash Preview (Sep 2025)",
+    "rateLimit": 400000000,
+    "providers": [
+      {
+        "vertex": "gemini-2.5-flash-preview-09-2025"
+      }
+    ],
+    "modality": "chat"
+  },
+  {
     "type": "google/gemini-2.5-flash",
     "displayName": "Gemini 2.5 Flash",
     "rateLimit": 400000000,

--- a/packages/shared-data/json/supported-models.json
+++ b/packages/shared-data/json/supported-models.json
@@ -35,12 +35,12 @@
     "modality": "chat"
   },
   {
-    "type": "google/gemini-2.5-flash-lite",
-    "displayName": "Gemini 2.5 Flash Lite",
+    "type": "google/gemini-2.5-flash-lite-preview-09-2025",
+    "displayName": "Gemini 2.5 Flash Lite Preview (Sep 2025)",
     "rateLimit": 400000000,
     "providers": [
       {
-        "vertex": "gemini-2.5-flash-lite"
+        "vertex": "gemini-2.5-flash-lite-preview-09-2025"
       }
     ],
     "modality": "chat"

--- a/packages/shared-data/json/supported-models.json
+++ b/packages/shared-data/json/supported-models.json
@@ -35,17 +35,6 @@
     "modality": "chat"
   },
   {
-    "type": "google/gemini-2.5-flash",
-    "displayName": "Gemini 2.5 Flash",
-    "rateLimit": 400000000,
-    "providers": [
-      {
-        "vertex": "gemini-2.5-flash"
-      }
-    ],
-    "modality": "chat"
-  },
-  {
     "type": "google/gemini-2.5-flash-lite",
     "displayName": "Gemini 2.5 Flash Lite",
     "rateLimit": 400000000,


### PR DESCRIPTION
This solves [HEB-207](https://linear.app/heboai/issue/HEB-207/gateway-upgrade-to-gemini-25-preview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 2.5 Flash Preview (Sep 2025) and Google Gemini 2.5 Flash Lite Preview (Sep 2025), expanding available AI model options for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->