### PR TITLE
Turisanapo/heb 262 auth fix api key

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -80,8 +80,8 @@ export const auth = betterAuth({
       enableSessionForAPIKeys: true,
       rateLimit: {
         enabled: true,
-        timeWindow: 60 * 1000,
-        maxRequests: 100,
+        timeWindow: 1000 * 60 * 60, // Per hour
+        maxRequests: 3600, // 3600 requests per hour
       },
       customAPIKeyGetter: (ctx) =>
         ctx.request?.headers.get("authorization")?.replace("Bearer ", "") ??

--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -78,6 +78,11 @@ export const auth = betterAuth({
       defaultPrefix: "sk_",
       enableMetadata: true,
       enableSessionForAPIKeys: true,
+      rateLimit: {
+        enabled: true,
+        timeWindow: 60 * 1000,
+        maxRequests: 100,
+      },
       customAPIKeyGetter: (ctx) =>
         ctx.request?.headers.get("authorization")?.replace("Bearer ", "") ??
         // eslint-disable-next-line unicorn/no-null

--- a/packages/shared-api/middlewares/auth/better-auth.ts
+++ b/packages/shared-api/middlewares/auth/better-auth.ts
@@ -63,8 +63,19 @@ export const authServiceBetterAuth = new Elysia({
         authClient: undefined,
       } as const;
     }
+
+    // For API key sessions, activeOrganizationId is missing (mock session bypasses hooks).
+    // Fall back to fetching from organization list.
+    let organizationId = session.session.activeOrganizationId;
+    if (!organizationId) {
+      const { data: orgs } = await authClient.organization.list();
+      if (orgs && orgs.length > 0) {
+        organizationId = orgs[0].id;
+      }
+    }
+
     return {
-      organizationId: session.session.activeOrganizationId,
+      organizationId,
       userId: session.user.id,
       authClient,
     } as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key requests are now rate-limited: enabled with a 60-minute window and a 3,600-request cap.

* **Bug Fixes**
  * Improved organization detection for API key sessions with an automatic fallback to select a primary organization when none is set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->