### PR TITLE
fix(console): sourcemaps for client components

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -46,8 +46,8 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@hebo/typescript-config": "workspace:*",
     "@babel/preset-typescript": "^7.28.5",
+    "@hebo/typescript-config": "workspace:*",
     "@mdx-js/react": "^3.1.1",
     "@mdx-js/rollup": "^3.1.1",
     "@msw/data": "^1.1.2",
@@ -60,15 +60,16 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "chaos-monkey": "^0.7.2",
     "msw": "^2.12.7",
+    "rollup-preserve-directives": "^1.1.3",
     "shiki": "^3.21.0",
     "slugify": "^1.6.6",
     "tailwindcss": "catalog:",
     "tw-animate-css": "catalog:",
+    "typescript": "catalog:",
     "vite": "^7.3.1",
     "vite-plugin-babel": "^1.4.1",
     "vite-plugin-devtools-json": "^1.0.0",
-    "vite-tsconfig-paths": "^6.0.4",
-    "typescript": "catalog:"
+    "vite-tsconfig-paths": "^6.0.4"
   },
   "msw": {
     "workerDirectory": [

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -2,6 +2,7 @@ import mdx from "@mdx-js/rollup";
 import { reactRouter } from "@react-router/dev/vite";
 import rehypeShiki from "@shikijs/rehype";
 import tailwindcss from "@tailwindcss/vite";
+import preserveDirectives from "rollup-preserve-directives";
 import { defineConfig, loadEnv } from "vite";
 import babel from "vite-plugin-babel";
 import devtoolsJson from "vite-plugin-devtools-json";
@@ -13,6 +14,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       tsconfigPaths(),
+      preserveDirectives(),
       mdx({
         providerImportSource: "~console/mdx-components",
         rehypePlugins: [

--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,7 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "chaos-monkey": "^0.7.2",
         "msw": "^2.12.7",
+        "rollup-preserve-directives": "^1.1.3",
         "shiki": "^3.21.0",
         "slugify": "^1.6.6",
         "tailwindcss": "catalog:",
@@ -2556,6 +2557,8 @@
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
+
+    "rollup-preserve-directives": ["rollup-preserve-directives@1.1.3", "", { "dependencies": { "magic-string": "^0.30.5" }, "peerDependencies": { "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0" } }, "sha512-oXqxd6ZzkoQej8Qt0k+S/yvO2+S4CEVEVv2g85oL15o0cjAKTKEuo2MzyA8FcsBBXbtytBzBMFAbhvQg4YyPUQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 


### PR DESCRIPTION
This fixes the following errors during console build:

vite v7.3.1 building client environment for production...
../../packages/shared-ui/src/_shadcn/ui/tooltip.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../packages/shared-ui/src/_shadcn/ui/sidebar.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../packages/shared-ui/src/_shadcn/ui/dropdown-menu.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../packages/shared-ui/src/_shadcn/ui/dialog.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../packages/shared-ui/src/_shadcn/ui/select.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
../../packages/shared-ui/src/_shadcn/ui/field.tsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies and configuration to enhance the build pipeline.
  * Improved directive handling during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->