### PR TITLE
feat(gateway): set idle timeout for load balancer to 5 minutes

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -5,14 +5,9 @@ on:
     types: [labeled]
 
 jobs:
-  quality:
-    name: Run Quality Checks
-    if: ${{ github.event.label.name == 'preview deploy' }}
-    uses: ./.github/workflows/quality.yml
-
   deploy:
     name: Deploy to Preview
-    needs: quality
+    if: ${{ github.event.label.name == 'preview deploy' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -51,6 +51,9 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
     ],
   },
   transform: {
+    loadBalancer: (args) => {
+      args.idleTimeout = 300; // 5 minutes
+    },
     listener: (args) => {
       if (args.protocol === "HTTPS") {
         args.sslPolicy = "ELBSecurityPolicy-TLS13-1-2-2021-06";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated gateway idle timeout to 5 minutes to improve connection lifecycle management.
  * Simplified preview deployment flow: removed the separate quality-check step and made preview deploy run only when the preview-deploy label is applied, consolidating deployment into a single guarded job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->