### PR TITLE
feat(greptime): add private NLB

### DIFF
--- a/infra/k8s/greptime/cluster.yaml
+++ b/infra/k8s/greptime/cluster.yaml
@@ -24,6 +24,12 @@ addons:
   - name: eks-pod-identity-agent
   - name: aws-ebs-csi-driver
 
+podIdentityAssociations:
+  - namespace: kube-system
+    serviceAccountName: aws-load-balancer-controller
+    wellKnownPolicies:
+      awsLoadBalancerController: true
+
 managedNodeGroups:
   - name: ng-arm
     amiFamily: AmazonLinux2023

--- a/infra/k8s/greptime/cluster.yaml
+++ b/infra/k8s/greptime/cluster.yaml
@@ -24,12 +24,6 @@ addons:
   - name: eks-pod-identity-agent
   - name: aws-ebs-csi-driver
 
-podIdentityAssociations:
-  - namespace: kube-system
-    serviceAccountName: aws-load-balancer-controller
-    wellKnownPolicies:
-      awsLoadBalancerController: true
-
 managedNodeGroups:
   - name: ng-arm
     amiFamily: AmazonLinux2023

--- a/infra/k8s/greptime/eks-deployment-runbook.md
+++ b/infra/k8s/greptime/eks-deployment-runbook.md
@@ -2,9 +2,9 @@
 
 From-scratch runbook for deploying GreptimeDB on EKS with a mostly declarative `eksctl` flow.
 
-It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (Pod Identity for the AWS Load Balancer Controller and EKS managed addons, IRSA for Greptime datanodes), EBS CSI, AWS Load Balancer Controller (internal NLB), S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require.
+It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, IRSA for Greptime datanodes, EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require.
 
-The frontend service is exposed only via an **internal NLB** (VPC-only). ECS services reach it through the private DNS name. Human access to the dashboard is via `kubectl port-forward`.
+The frontend service is exposed only via an **internal NLB** (VPC-only) using the in-tree cloud controller. ECS services reach it through the private DNS name. Human access to the dashboard is via `kubectl port-forward`.
 
 Environment-specific values (VPC, subnets, Aurora host, S3 bucket, IAM role, etc.) are marked as `<PLACEHOLDER>` in `cluster.yaml` and `greptime-values.yaml` -- replace them before running the corresponding steps.
 
@@ -23,18 +23,7 @@ Replace the `<PLACEHOLDER>` values in `cluster.yaml` with your VPC, subnet, and 
 eksctl create cluster -f infra/k8s/greptime/cluster.yaml
 ```
 
-## 2) Install the AWS Load Balancer Controller
-
-```
-helm repo add eks https://aws.github.io/eks-charts
-helm repo update
-
-helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
-  -n kube-system \
-  --set clusterName="<CLUSTER_NAME>"
-```
-
-## 3) Create S3 bucket (object storage)
+## 2) Create S3 bucket (object storage)
 
 ```
 aws s3api create-bucket \
@@ -43,7 +32,7 @@ aws s3api create-bucket \
   --create-bucket-configuration LocationConstraint="<AWS_REGION>"
 ```
 
-## 4) Install GreptimeDB operator (Helm)
+## 3) Install GreptimeDB operator (Helm)
 
 ```
 helm repo add greptime https://greptimeteam.github.io/helm-charts/
@@ -52,7 +41,7 @@ helm repo update
 helm upgrade --install greptimedb-operator greptime/greptimedb-operator -n greptimedb-admin --create-namespace
 ```
 
-## 5) Deploy Greptime cluster (Helm)
+## 4) Deploy Greptime cluster (Helm)
 
 Replace the `<PLACEHOLDER>` values in `greptime-values.yaml` with your Aurora host, database, S3 bucket, and region before running.
 
@@ -62,7 +51,7 @@ helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
   -f infra/k8s/greptime/greptime-values.yaml
 ```
 
-## 6) Create IAM role for datanode S3 access (IRSA)
+## 5) Create IAM role for datanode S3 access (IRSA)
 
 Use an S3 policy ARN, then let `eksctl` create the IRSA role/trust for the datanode service account.
 Set `<GREPTIME_S3_ROLE_ARN>` in `greptime-values.yaml` to the printed role ARN, then run Helm upgrade again to apply it.
@@ -81,7 +70,7 @@ eksctl create iamserviceaccount \
 aws iam get-role --role-name "GreptimeS3Role-<CLUSTER_NAME>" --query 'Role.Arn' --output text
 ```
 
-## 7) Apply updated Helm values (role ARN)
+## 6) Apply updated Helm values (role ARN)
 
 ```
 helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
@@ -89,7 +78,7 @@ helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
   -f infra/k8s/greptime/greptime-values.yaml
 ```
 
-## 8) Create Aurora credentials secret (metasrv backend)
+## 7) Create Aurora credentials secret (metasrv backend)
 
 ```
 kubectl -n "$GREPTIME_NS" create secret generic meta-postgresql-credentials \
@@ -97,13 +86,13 @@ kubectl -n "$GREPTIME_NS" create secret generic meta-postgresql-credentials \
   --from-literal=password="<POSTGRES_PASSWORD>"
 ```
 
-## 9) Restart Greptime workloads (pick up secret and updated ServiceAccount configuration)
+## 8) Restart Greptime workloads (pick up secret and updated ServiceAccount configuration)
 
 ```
 kubectl -n "$GREPTIME_NS" rollout restart deployment,statefulset
 ```
 
-## 10) Verify (pods, service, health, load balancer)
+## 9) Verify (pods, service, health, load balancer)
 
 ```
 # Pods should be Running/Ready

--- a/infra/k8s/greptime/eks-deployment-runbook.md
+++ b/infra/k8s/greptime/eks-deployment-runbook.md
@@ -2,7 +2,7 @@
 
 From-scratch runbook for deploying GreptimeDB on EKS with a mostly declarative `eksctl` flow.
 
-It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, IRSA for Greptime datanodes, EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require.
+It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (IRSA for Greptime datanodes + Pod Identity for EKS managed addons), EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require,
 
 The frontend service is exposed only via an **internal NLB** (VPC-only) using the in-tree cloud controller. ECS services reach it through the private DNS name. Human access to the dashboard is via `kubectl port-forward`.
 
@@ -92,7 +92,7 @@ kubectl -n "$GREPTIME_NS" create secret generic meta-postgresql-credentials \
 kubectl -n "$GREPTIME_NS" rollout restart deployment,statefulset
 ```
 
-## 9) Verify (pods, service, health, load balancer)
+## 9) Verify (pods, service, health, meta logs)
 
 ```
 # Pods should be Running/Ready

--- a/infra/k8s/greptime/eks-deployment-runbook.md
+++ b/infra/k8s/greptime/eks-deployment-runbook.md
@@ -2,7 +2,7 @@
 
 From-scratch runbook for deploying GreptimeDB on EKS with a mostly declarative `eksctl` flow.
 
-It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (IRSA for Greptime datanodes + Pod Identity for EKS managed addons), EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require,
+It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (IRSA for Greptime datanodes + Pod Identity for EKS managed addons), EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require.
 
 The frontend service is exposed only via an **internal NLB** (VPC-only) using the in-tree cloud controller. ECS services reach it through the private DNS name. Human access to the dashboard is via `kubectl port-forward`.
 

--- a/infra/k8s/greptime/eks-deployment-runbook.md
+++ b/infra/k8s/greptime/eks-deployment-runbook.md
@@ -2,7 +2,9 @@
 
 From-scratch runbook for deploying GreptimeDB on EKS with a mostly declarative `eksctl` flow.
 
-It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (IRSA for Greptime datanodes + Pod Identity for EKS managed addons), EBS CSI, S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require, internal LoadBalancer for the frontend.
+It deploys: EKS 1.35, AL2023, 3x m7g.large, 3 AZs, hybrid IAM wiring (Pod Identity for the AWS Load Balancer Controller and EKS managed addons, IRSA for Greptime datanodes), EBS CSI, AWS Load Balancer Controller (internal NLB), S3 object storage, EBS WAL, Aurora Postgres metadata with SSL Require.
+
+The frontend service is exposed only via an **internal NLB** (VPC-only). ECS services reach it through the private DNS name. Human access to the dashboard is via `kubectl port-forward`.
 
 Environment-specific values (VPC, subnets, Aurora host, S3 bucket, IAM role, etc.) are marked as `<PLACEHOLDER>` in `cluster.yaml` and `greptime-values.yaml` -- replace them before running the corresponding steps.
 
@@ -21,7 +23,18 @@ Replace the `<PLACEHOLDER>` values in `cluster.yaml` with your VPC, subnet, and 
 eksctl create cluster -f infra/k8s/greptime/cluster.yaml
 ```
 
-## 2) Create S3 bucket (object storage)
+## 2) Install the AWS Load Balancer Controller
+
+```
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update
+
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName="<CLUSTER_NAME>"
+```
+
+## 3) Create S3 bucket (object storage)
 
 ```
 aws s3api create-bucket \
@@ -30,7 +43,7 @@ aws s3api create-bucket \
   --create-bucket-configuration LocationConstraint="<AWS_REGION>"
 ```
 
-## 3) Install GreptimeDB operator (Helm)
+## 4) Install GreptimeDB operator (Helm)
 
 ```
 helm repo add greptime https://greptimeteam.github.io/helm-charts/
@@ -39,7 +52,7 @@ helm repo update
 helm upgrade --install greptimedb-operator greptime/greptimedb-operator -n greptimedb-admin --create-namespace
 ```
 
-## 4) Deploy Greptime cluster (Helm)
+## 5) Deploy Greptime cluster (Helm)
 
 Replace the `<PLACEHOLDER>` values in `greptime-values.yaml` with your Aurora host, database, S3 bucket, and region before running.
 
@@ -49,7 +62,7 @@ helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
   -f infra/k8s/greptime/greptime-values.yaml
 ```
 
-## 5) Create IAM role for datanode S3 access (IRSA)
+## 6) Create IAM role for datanode S3 access (IRSA)
 
 Use an S3 policy ARN, then let `eksctl` create the IRSA role/trust for the datanode service account.
 Set `<GREPTIME_S3_ROLE_ARN>` in `greptime-values.yaml` to the printed role ARN, then run Helm upgrade again to apply it.
@@ -68,7 +81,7 @@ eksctl create iamserviceaccount \
 aws iam get-role --role-name "GreptimeS3Role-<CLUSTER_NAME>" --query 'Role.Arn' --output text
 ```
 
-## 6) Apply updated Helm values (role ARN)
+## 7) Apply updated Helm values (role ARN)
 
 ```
 helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
@@ -76,7 +89,7 @@ helm upgrade --install "$HELM_RELEASE_CLUSTER" greptime/greptimedb-cluster \
   -f infra/k8s/greptime/greptime-values.yaml
 ```
 
-## 7) Create Aurora credentials secret (metasrv backend)
+## 8) Create Aurora credentials secret (metasrv backend)
 
 ```
 kubectl -n "$GREPTIME_NS" create secret generic meta-postgresql-credentials \
@@ -84,13 +97,13 @@ kubectl -n "$GREPTIME_NS" create secret generic meta-postgresql-credentials \
   --from-literal=password="<POSTGRES_PASSWORD>"
 ```
 
-## 8) Restart Greptime workloads (pick up secret and updated ServiceAccount configuration)
+## 9) Restart Greptime workloads (pick up secret and updated ServiceAccount configuration)
 
 ```
 kubectl -n "$GREPTIME_NS" rollout restart deployment,statefulset
 ```
 
-## 9) Verify (pods, service, health, meta logs)
+## 10) Verify (pods, service, health, load balancer)
 
 ```
 # Pods should be Running/Ready

--- a/infra/k8s/greptime/greptime-values.yaml
+++ b/infra/k8s/greptime/greptime-values.yaml
@@ -2,6 +2,7 @@ frontend:
   replicas: 3
   service:
     type: LoadBalancer
+    loadBalancerClass: "service.k8s.aws/nlb"
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
 

--- a/infra/k8s/greptime/greptime-values.yaml
+++ b/infra/k8s/greptime/greptime-values.yaml
@@ -2,9 +2,9 @@ frontend:
   replicas: 3
   service:
     type: LoadBalancer
-    loadBalancerClass: "service.k8s.aws/nlb"
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
 
 meta:
   replicas: 3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified frontend access: now reachable via internal private DNS and via kubectl port‑forward for human access.
  * Added verification steps for the new internal load balancer setup.

* **Updates**
  * Switched frontend exposure to an internal NLB (VPC-only) to improve intra-network access; ECS services use private DNS to reach the frontend.
  * Removed previous internal LoadBalancer exposure method from deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->