### PR TITLE
refactor(otel): avoid early init of the metric exporter

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -24,7 +24,7 @@
     "@elysiajs/cors": "catalog:",
     "@elysiajs/openapi": "catalog:",
     "@elysiajs/opentelemetry": "catalog:",
-    "@hebo-ai/gateway": "0.6.2-rc0",
+    "@hebo-ai/gateway": "0.6.2-rc1",
     "@hebo/api": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
         "@elysiajs/cors": "catalog:",
         "@elysiajs/openapi": "catalog:",
         "@elysiajs/opentelemetry": "catalog:",
-        "@hebo-ai/gateway": "0.6.2-rc0",
+        "@hebo-ai/gateway": "0.6.2-rc1",
         "@hebo/api": "workspace:*",
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
@@ -546,7 +546,7 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.6.2-rc0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@opentelemetry/api": "^1.9.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "voyage-ai-provider"] }, "sha512-sxmlyCcqi/zl/PjHQRTUHNEV+48+JsoLlmHw71oQvh3i+kmtgJNG2VWmzuQ4Eqb41hsD/YuzJT5TymgfCPplQw=="],
+    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.6.2-rc1", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@opentelemetry/api": "^1.9.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "voyage-ai-provider"] }, "sha512-5bwk7Sp/A9B2zmo+8nGq0uAT8cC/EGBmoGs66r+JMyBgz5rlAjHRgxCczHN/qUNnwZgZ3IzOwBdd7avtIAMO1A=="],
 
     "@hebo/aikit-ui": ["@hebo/aikit-ui@workspace:packages/aikit-ui"],
 

--- a/packages/shared-api/lib/otel.ts
+++ b/packages/shared-api/lib/otel.ts
@@ -1,5 +1,4 @@
 import type { ElysiaOpenTelemetryOptions } from "@elysiajs/opentelemetry";
-import { metrics } from "@opentelemetry/api";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
@@ -13,7 +12,7 @@ import {
   SimpleLogRecordProcessor,
   createLoggerConfigurator,
 } from "@opentelemetry/sdk-logs";
-import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import {
   type BufferConfig,
   type SpanExporter,
@@ -33,23 +32,6 @@ const SensitiveSpanAttributes = [
 
 export const greptimeOtlpEndpoint =
   (await getSecret("GreptimeEndpoint")) ?? "http://localhost:4000/v1/otlp";
-
-// Register the MeterProvider eagerly so that any library calling
-// metrics.getMeter() at import time gets a real meter instead of a NoopMeter.
-// Unlike traces, the metrics API does not use proxies — meters created before
-// the provider is registered stay noop forever.
-metrics.setGlobalMeterProvider(
-  new MeterProvider({
-    readers: [
-      new PeriodicExportingMetricReader({
-        exporter: new OTLPMetricExporter({
-          url: `${greptimeOtlpEndpoint}/v1/metrics`,
-          compression: CompressionAlgorithm.GZIP,
-        }),
-      }),
-    ],
-  }),
-);
 
 export const getOtelLogger = (serviceName: string, minimumSeverity: SeverityNumber) => {
   const loggerProvider = new LoggerProvider({
@@ -124,6 +106,12 @@ const createRedactingBatchSpanProcessor = (exporter: SpanExporter, config?: Buff
 export const getOtelConfig = (serviceName: string): ElysiaOpenTelemetryOptions => {
   return {
     serviceName,
+    metricReader: new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        url: `${greptimeOtlpEndpoint}/v1/metrics`,
+        compression: CompressionAlgorithm.GZIP,
+      }),
+    }),
     checkIfShouldTrace: (request) => {
       if (request.method !== "GET") return true;
       return !isRootPathUrl(request.url);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway dependency to latest pre-release version.

* **Refactor**
  * Optimized metrics configuration handling for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->