### PR TITLE
fix(console): refresh session proactively before API calls

### DIFF
--- a/apps/console/app/lib/service.ts
+++ b/apps/console/app/lib/service.ts
@@ -3,6 +3,7 @@ import ky, { HTTPError } from "ky";
 import type { Api } from "~api";
 import type { Gateway } from "~gateway";
 
+import { authService } from "~console/lib/auth";
 import { useMocks } from "~console/lib/env";
 
 export const apiUrl = useMocks
@@ -20,6 +21,11 @@ export const kyFetch = ky.extend({
   timeout: 60_000, // 60 seconds
   throwHttpErrors: false,
   hooks: {
+    beforeRequest: [
+      async () => {
+        await authService.ensureSignedIn();
+      },
+    ],
     afterResponse: [
       async (_req, _opts, res) => {
         // Successful response, all good


### PR DESCRIPTION
Fixes #201

Calls `ensureSignedIn()` in `kyFetch`'s `beforeRequest` hook to refresh the `session_data` cookie when it expires (default 5 min TTL), preventing "unauthorized" errors after periods of inactivity.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened authentication verification for API requests across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->