### PR TITLE
feat(auth): switch API keys from user-scoped to organization-scoped

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -49,7 +49,7 @@ export const auth = betterAuth({
       },
       defaultPrefix: "sk_",
       enableMetadata: true,
-      enableSessionForAPIKeys: true,
+
       rateLimit: {
         enabled: false,
       },

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -69,23 +69,34 @@ export const authService: AuthService = {
       .join("");
 
     shellStore.user = user;
+    shellStore.organizationId = session.data.session.activeOrganizationId;
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
     // Better Auth expects seconds.
     const expiresIn = Math.max(1, Math.floor(expiresInMs / 1000));
-    const { data, error } = await authClient.apiKey.create({ name, expiresIn });
+    const { data, error } = await authClient.apiKey.create({
+      name,
+      expiresIn,
+      organizationId: shellStore.organizationId,
+      metadata: { createdByUserId: shellStore.user?.email },
+    });
     if (error) throw new Error(error.message);
     return data as ApiKey;
   },
 
   async revokeApiKey(apiKeyId) {
-    const { error } = await authClient.apiKey.delete({ keyId: apiKeyId });
+    const { error } = await authClient.apiKey.delete({
+      keyId: apiKeyId,
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
   },
 
   async listApiKeys() {
-    const { data, error } = await authClient.apiKey.list();
+    const { data, error } = await authClient.apiKey.list({
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
     const keys = data.apiKeys.map((key) => ({
       ...key,
@@ -129,5 +140,6 @@ export const authService: AuthService = {
   async signOut() {
     await authClient.signOut();
     shellStore.user = undefined;
+    shellStore.organizationId = undefined;
   },
 };

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -24,6 +24,7 @@ export const authService = {
       initials: "DU",
       image: "",
     };
+    shellStore.organizationId = "dummy-org-id";
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
@@ -58,5 +59,6 @@ export const authService = {
 
   async signOut() {
     shellStore.user = undefined;
+    shellStore.organizationId = undefined;
   },
 } satisfies AuthService;

--- a/apps/console/app/lib/shell.ts
+++ b/apps/console/app/lib/shell.ts
@@ -14,8 +14,10 @@ export type Models = Record<
 
 export const shellStore = proxy<{
   user: User | undefined;
+  organizationId: string | undefined;
   models: Models | undefined;
 }>({
   user: undefined,
+  organizationId: undefined,
   models: undefined,
 });

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
@@ -74,7 +74,7 @@ export default function ApiKeysRoute({ loaderData }: Route.ComponentProps) {
       <div>
         <h1>API Keys</h1>
         <p className="text-sm text-muted-foreground">
-          Issue and revoke API keys to access your agent programmatically.
+          Manage organization API keys to access your agent programmatically.
         </p>
       </div>
 

--- a/packages/shared-api/middlewares/auth.ts
+++ b/packages/shared-api/middlewares/auth.ts
@@ -13,7 +13,7 @@ const cookieConfig = getCookies(betterAuthCookieOptions);
 
 const createAuthClient = (request: Request) => {
   const headers = new Headers();
-  for (const name of ["cookie", "authorization", "origin"]) {
+  for (const name of ["cookie", "origin"]) {
     const value = request.headers.get(name);
     if (value) headers.set(name, value);
   }
@@ -45,6 +45,32 @@ const createAuthClient = (request: Request) => {
   });
 };
 
+type VerifyApiKeyResponse = {
+  valid: boolean;
+  key?: {
+    userId: string;
+    referenceId: string;
+  };
+  error?: string;
+};
+
+const verifyApiKey = async (key: string): Promise<VerifyApiKeyResponse> => {
+  const headers = new Headers({ "Content-Type": "application/json" });
+
+  // Inject OTEL trace context for distributed tracing
+  propagation.inject(context.active(), headers, {
+    set: (carrier, key, value) => carrier.set(key, value),
+  });
+
+  const response = await fetch(new URL("/v1/api-key/verify", authUrl), {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ key }),
+  });
+
+  return response.json() as Promise<VerifyApiKeyResponse>;
+};
+
 export const authService = new Elysia({ name: "auth-service" })
   .resolve(async function resolveAuthContext(ctx) {
     const logger = (ctx as unknown as { logger: Logger }).logger;
@@ -55,22 +81,37 @@ export const authService = new Elysia({ name: "auth-service" })
       throw new BadRequestError("Provide exactly one credential: Bearer API Key or JWT Header");
     }
 
-    const authClient = createAuthClient(ctx.request);
-
-    let session, error;
+    let organizationId: string | undefined;
+    let userId: string | undefined;
+    let authClient: ReturnType<typeof createAuthClient> | undefined;
 
     if (cookie) {
-      session = await getCookieCache(ctx.request, {
+      const session = await getCookieCache(ctx.request, {
         secret: authSecret,
         isSecure: betterAuthCookieOptions.advanced.useSecureCookies,
       });
-    } else {
-      ({ data: session, error } = await authClient.getSession());
+
+      if (session) {
+        organizationId = session.session.activeOrganizationId;
+        userId = session.user.id;
+        authClient = createAuthClient(ctx.request);
+      } else {
+        logger.info("Cookie auth failed: no valid session");
+      }
+    } else if (authorization) {
+      const key = authorization.replace("Bearer ", "");
+      const result = await verifyApiKey(key);
+
+      if (result.valid && result.key) {
+        // For org-owned API keys, referenceId is the organization ID
+        organizationId = result.key.referenceId;
+        userId = result.key.userId;
+      } else {
+        logger.info({ error: result.error }, "API key verification failed");
+      }
     }
 
-    if (error || !session) {
-      logger.info({ error }, "Authentication failed or no credentials provided");
-
+    if (!organizationId || !userId) {
       // Clear the session cookie when unauthorized
       const { attributes, name } = cookieConfig.sessionToken;
       ctx.cookie[name] = {
@@ -86,19 +127,9 @@ export const authService = new Elysia({ name: "auth-service" })
       } as const;
     }
 
-    // For API key sessions, activeOrganizationId is missing (mock session bypasses hooks).
-    // Fall back to fetching from organization list.
-    let organizationId = session.session.activeOrganizationId;
-    if (!organizationId) {
-      const { data: orgs } = await authClient.organization.list();
-      if (orgs && orgs.length > 0) {
-        organizationId = orgs[0].id;
-      }
-    }
-
     return {
       organizationId,
-      userId: session.user.id,
+      userId,
       authClient,
     } as const;
   })


### PR DESCRIPTION
Switches API keys from user-scoped to organization-scoped using better-auth 1.5’s native org-owned key support.

- Pass `organizationId` to `apiKey.create/list/delete` in console client
- Replace `authClient.getSession()` with `fetch` to `/v1/api-key/verify` for API key auth (keeps service-to-service separation)
- Remove fragile `organization.list()` fallback
- Remove `enableSessionForAPIKeys` (no longer needed)
- Store `createdByUserId` in key metadata for audit trail
- Store `organizationId` in `shellStore`, set during `ensureSignedIn()`
- Update UI copy to reflect organization API keys

Closes #216

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API key authentication now supported as an alternative to session-based access.
  * API keys are now scoped and managed at the organization level with enhanced tracking.

* **Improvements**
  * Updated API key management interface messaging for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->