### PR TITLE
fix(console): proactive session refresh before API calls

### DIFF
--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -3,7 +3,7 @@ import { createAuthClient } from "better-auth/client";
 import { emailOTPClient, organizationClient } from "better-auth/client/plugins";
 import { getSessionCookie } from "better-auth/cookies";
 
-import { authUrl } from "~console/lib/service";
+import { authUrl } from "~console/lib/env";
 import { shellStore } from "~console/lib/shell";
 
 import { DEFAULT_EXPIRATION_MS, type ApiKey, type AuthService, type User } from "./types";
@@ -34,21 +34,21 @@ const authClient = createAuthClient({
 const redirectToSignIn = () => {
   shellStore.user = undefined;
   globalThis.location.replace("/signin");
+  return false as const;
 };
 
 export const authService: AuthService = {
   async ensureSignedIn() {
     const headers = new Headers({ cookie: document.cookie });
     if (!getSessionCookie(headers)) {
-      redirectToSignIn();
-      return;
+      return redirectToSignIn();
     }
 
     const hasSessionDataCookie = getSessionCookie(headers, {
       cookieName: "session_data",
     });
     if (shellStore.user && hasSessionDataCookie) {
-      return;
+      return true;
     }
 
     // Disable cookie cache only after fresh sign-in to ensure we get the latest session
@@ -57,8 +57,7 @@ export const authService: AuthService = {
       query: { disableCookieCache: isComingFromSignIn },
     });
     if (!session?.data?.user) {
-      redirectToSignIn();
-      return;
+      return redirectToSignIn();
     }
     const user = session.data.user as User;
     const initialsSource = user?.name || user.email;
@@ -69,6 +68,7 @@ export const authService: AuthService = {
       .join("");
 
     shellStore.user = user;
+    return true;
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -17,13 +17,14 @@ const apiKeys = new Collection({
 
 export const authService = {
   async ensureSignedIn() {
-    if (shellStore.user) return;
+    if (shellStore.user) return true;
     shellStore.user = {
       name: "Dummy User",
       email: "dummy@user.com",
       initials: "DU",
       image: "",
     };
+    return true;
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {

--- a/apps/console/app/lib/auth/types.ts
+++ b/apps/console/app/lib/auth/types.ts
@@ -1,5 +1,5 @@
 export interface AuthService {
-  ensureSignedIn(): Promise<void>;
+  ensureSignedIn(): Promise<boolean>;
   generateApiKey(name: string, expiresInMs?: number): Promise<ApiKey>;
   revokeApiKey(apiKeyId: string): Promise<void>;
   listApiKeys(): Promise<Array<ApiKey>>;

--- a/apps/console/app/lib/env.ts
+++ b/apps/console/app/lib/env.ts
@@ -7,3 +7,13 @@ const isReachable = (url: string) =>
   );
 
 export const useMocks = shouldAutoDetect && !(await isReachable("http://localhost:3001"));
+
+export const apiUrl = useMocks
+  ? "http://localhost:5173/api"
+  : import.meta.env.VITE_API_URL || "http://localhost:3001";
+
+export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:3000";
+
+export const gatewayUrl = useMocks
+  ? "http://localhost:5173/gateway"
+  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:3002";

--- a/apps/console/app/lib/service.ts
+++ b/apps/console/app/lib/service.ts
@@ -3,23 +3,22 @@ import ky, { HTTPError } from "ky";
 import type { Api } from "~api";
 import type { Gateway } from "~gateway";
 
-import { useMocks } from "~console/lib/env";
-
-export const apiUrl = useMocks
-  ? "http://localhost:5173/api"
-  : import.meta.env.VITE_API_URL || "http://localhost:3001";
-
-export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:3000";
-
-export const gatewayUrl = useMocks
-  ? "http://localhost:5173/gateway"
-  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:3002";
+import { authService } from "~console/lib/auth";
+import { apiUrl, gatewayUrl } from "~console/lib/env";
 
 export const kyFetch = ky.extend({
   credentials: "include",
   timeout: 60_000, // 60 seconds
   throwHttpErrors: false,
   hooks: {
+    beforeRequest: [
+      async () => {
+        const signedIn = await authService.ensureSignedIn();
+        if (!signedIn) {
+          return new Response(null, { status: 204 });
+        }
+      },
+    ],
     afterResponse: [
       async (_req, _opts, res) => {
         // Successful response, all good

--- a/apps/console/app/routes/_shell/sidebar-playground.tsx
+++ b/apps/console/app/routes/_shell/sidebar-playground.tsx
@@ -1,6 +1,7 @@
 import { Chat } from "@hebo/aikit-ui/blocks/Chat";
 
-import { gatewayUrl, kyFetch } from "~console/lib/service";
+import { gatewayUrl } from "~console/lib/env";
+import { kyFetch } from "~console/lib/service";
 
 type Agent = {
   name: string;


### PR DESCRIPTION
Fixes #201

When the better-auth cookie cache expires (default 5 min TTL), the `session_data` cookie disappears and the gateway returns 401. This fix calls `ensureSignedIn()` in `kyFetch`'s `beforeRequest` hook to proactively refresh the cookie. If the session can't be refreshed, it returns a synthetic `Response(null, { status: 204 })` to prevent ky from making the real request (and avoid the afterResponse hook throwing on 401).

- Move `apiUrl`, `authUrl`, `gatewayUrl` from `service.ts` to `env.ts`
- Change `ensureSignedIn()` return type to `Promise<boolean>`
- Add `beforeRequest` hook returning synthetic 204 Response when session is invalid

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized authentication and configuration management across modules to improve code structure and maintainability.
  * Enhanced authentication verification logic to better track sign-in status.
  * Implemented automatic authentication checks for API requests to ensure valid user sessions before processing.
  * Improved handling of environment variables for service endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->