### PR TITLE
feat(auth): switch API keys from user-scoped to organization-scoped

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -49,7 +49,6 @@ export const auth = betterAuth({
       },
       defaultPrefix: "sk_",
       enableMetadata: true,
-      enableSessionForAPIKeys: true,
       rateLimit: {
         enabled: false,
       },

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -47,7 +47,7 @@ export const authService: AuthService = {
     const hasSessionDataCookie = getSessionCookie(headers, {
       cookieName: "session_data",
     });
-    if (shellStore.user && hasSessionDataCookie) {
+    if (shellStore.user && shellStore.organizationId && hasSessionDataCookie) {
       return;
     }
 
@@ -69,23 +69,35 @@ export const authService: AuthService = {
       .join("");
 
     shellStore.user = user;
+    shellStore.userId = session.data.user.id;
+    shellStore.organizationId = session.data.session.activeOrganizationId;
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
     // Better Auth expects seconds.
     const expiresIn = Math.max(1, Math.floor(expiresInMs / 1000));
-    const { data, error } = await authClient.apiKey.create({ name, expiresIn });
+    const { data, error } = await authClient.apiKey.create({
+      name,
+      expiresIn,
+      organizationId: shellStore.organizationId,
+      metadata: { createdByUserId: shellStore.userId },
+    });
     if (error) throw new Error(error.message);
     return data as ApiKey;
   },
 
   async revokeApiKey(apiKeyId) {
-    const { error } = await authClient.apiKey.delete({ keyId: apiKeyId });
+    const { error } = await authClient.apiKey.delete({
+      keyId: apiKeyId,
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
   },
 
   async listApiKeys() {
-    const { data, error } = await authClient.apiKey.list();
+    const { data, error } = await authClient.apiKey.list({
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
     const keys = data.apiKeys.map((key) => ({
       ...key,
@@ -129,5 +141,7 @@ export const authService: AuthService = {
   async signOut() {
     await authClient.signOut();
     shellStore.user = undefined;
+    shellStore.userId = undefined;
+    shellStore.organizationId = undefined;
   },
 };

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -17,13 +17,15 @@ const apiKeys = new Collection({
 
 export const authService = {
   async ensureSignedIn() {
-    if (shellStore.user) return;
+    if (shellStore.user && shellStore.organizationId) return;
     shellStore.user = {
       name: "Dummy User",
       email: "dummy@user.com",
       initials: "DU",
       image: "",
     };
+    shellStore.userId = "dummy-user-id";
+    shellStore.organizationId = "dummy-org-id";
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
@@ -58,5 +60,7 @@ export const authService = {
 
   async signOut() {
     shellStore.user = undefined;
+    shellStore.userId = undefined;
+    shellStore.organizationId = undefined;
   },
 } satisfies AuthService;

--- a/apps/console/app/lib/shell.ts
+++ b/apps/console/app/lib/shell.ts
@@ -14,8 +14,12 @@ export type Models = Record<
 
 export const shellStore = proxy<{
   user: User | undefined;
+  userId: string | undefined;
+  organizationId: string | undefined;
   models: Models | undefined;
 }>({
   user: undefined,
+  userId: undefined,
+  organizationId: undefined,
   models: undefined,
 });

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
@@ -74,7 +74,7 @@ export default function ApiKeysRoute({ loaderData }: Route.ComponentProps) {
       <div>
         <h1>API Keys</h1>
         <p className="text-sm text-muted-foreground">
-          Issue and revoke API keys to access your agent programmatically.
+          Manage organization API keys to access your agent programmatically.
         </p>
       </div>
 

--- a/packages/shared-api/middlewares/auth.ts
+++ b/packages/shared-api/middlewares/auth.ts
@@ -11,9 +11,34 @@ import type { Logger } from "./logging";
 
 const cookieConfig = getCookies(betterAuthCookieOptions);
 
+const verifyApiKeyUrl = new URL("/v1/api-key/verify", authUrl).toString();
+
+type VerifyApiKeyResult =
+  | { valid: true; key: { userId: string; referenceId: string } }
+  | { valid: false };
+
+const verifyApiKey = async (key: string): Promise<VerifyApiKeyResult | null> => {
+  const headers = new Headers({ "content-type": "application/json" });
+  propagation.inject(context.active(), headers, {
+    set: (carrier, k, value) => carrier.set(k, value),
+  });
+
+  try {
+    const response = await fetch(verifyApiKeyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ key }),
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as VerifyApiKeyResult;
+  } catch {
+    return null;
+  }
+};
+
 const createAuthClient = (request: Request) => {
   const headers = new Headers();
-  for (const name of ["cookie", "authorization", "origin"]) {
+  for (const name of ["cookie", "origin"]) {
     const value = request.headers.get(name);
     if (value) headers.set(name, value);
   }
@@ -57,48 +82,62 @@ export const authService = new Elysia({ name: "auth-service" })
 
     const authClient = createAuthClient(ctx.request);
 
-    let session, error;
-
+    // Cookie auth path
     if (cookie) {
-      session = await getCookieCache(ctx.request, {
+      const session = await getCookieCache(ctx.request, {
         secret: authSecret,
         isSecure: betterAuthCookieOptions.advanced.useSecureCookies,
       });
-    } else {
-      ({ data: session, error } = await authClient.getSession());
-    }
 
-    if (error || !session) {
-      logger.info({ error }, "Authentication failed or no credentials provided");
+      if (!session) {
+        logger.info("Cookie authentication failed");
+        const { attributes, name } = cookieConfig.sessionToken;
+        ctx.cookie[name] = {
+          value: "",
+          maxAge: 0,
+          ...attributes,
+        } as Cookie<string>;
 
-      // Clear the session cookie when unauthorized
-      const { attributes, name } = cookieConfig.sessionToken;
-      ctx.cookie[name] = {
-        value: "",
-        maxAge: 0,
-        ...attributes,
-      } as Cookie<string>;
+        return {
+          organizationId: undefined,
+          userId: undefined,
+          authClient,
+        } as const;
+      }
 
       return {
-        organizationId: undefined,
-        userId: undefined,
-        authClient: undefined,
+        organizationId: session.session.activeOrganizationId as string | undefined,
+        userId: session.user.id,
+        authClient,
       } as const;
     }
 
-    // For API key sessions, activeOrganizationId is missing (mock session bypasses hooks).
-    // Fall back to fetching from organization list.
-    let organizationId = session.session.activeOrganizationId;
-    if (!organizationId) {
-      const { data: orgs } = await authClient.organization.list();
-      if (orgs && orgs.length > 0) {
-        organizationId = orgs[0].id;
+    // API key auth path
+    if (authorization) {
+      const key = authorization.replace("Bearer ", "");
+      const result = await verifyApiKey(key);
+
+      if (!result?.valid) {
+        logger.info("API key authentication failed");
+        return {
+          organizationId: undefined,
+          userId: undefined,
+          authClient,
+        } as const;
       }
+
+      // For org-owned API keys, referenceId is the organization ID
+      return {
+        organizationId: result.key.referenceId,
+        userId: result.key.userId,
+        authClient,
+      } as const;
     }
 
+    // No credentials provided
     return {
-      organizationId,
-      userId: session.user.id,
+      organizationId: undefined,
+      userId: undefined,
       authClient,
     } as const;
   })


### PR DESCRIPTION
Switches API keys from user-scoped to organization-scoped using better-auth 1.5’s native org-owned key support. Addresses all 4 code review comments from codex/coderabbit.

- Pass `organizationId` to `apiKey.create/list/delete` in console client
- Replace `authClient.getSession()` with `fetch` to `/v1/api-key/verify` for API key auth
- Always provide `authClient` in middleware (prevents undefined crash in agents.ts)
- Wrap `verifyApiKey` in try/catch for network error resilience
- Store actual user ID (not email) in key metadata for audit
- Guard early return in `ensureSignedIn` on `organizationId` presence
- Remove fragile `organization.list()` fallback
- Remove `enableSessionForAPIKeys` (no longer needed)
- Update UI copy to reflect organization API keys

Closes #216

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API key verification for secure authentication.
  * API keys now organization-scoped with creator attribution.

* **Bug Fixes**
  * Session management now properly validates organization context.

* **Documentation**
  * Updated API keys interface description to reflect organization-level management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->