### PR TITLE
feat(auth): switch API keys from user-scoped to organization-scoped

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -49,12 +49,14 @@ export const auth = betterAuth({
       },
       defaultPrefix: "sk_",
       enableMetadata: true,
-      enableSessionForAPIKeys: true,
       rateLimit: {
         enabled: false,
       },
-      customAPIKeyGetter: (ctx) =>
-        ctx.request?.headers.get("authorization")?.replace("Bearer ", "") ?? null,
+      customAPIKeyGetter: (ctx) => {
+        const header = ctx.request?.headers.get("authorization");
+        if (!header || header.length < 8 || header.substring(0, 7).toLowerCase() !== "bearer ") return null;
+        return header.substring(7);
+      },
     }),
     emailOTP({
       async sendVerificationOTP({ email, otp }, ctx) {

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -33,6 +33,8 @@ const authClient = createAuthClient({
 
 const redirectToSignIn = () => {
   shellStore.user = undefined;
+  shellStore.userId = undefined;
+  shellStore.organizationId = undefined;
   globalThis.location.replace("/signin");
 };
 
@@ -47,7 +49,7 @@ export const authService: AuthService = {
     const hasSessionDataCookie = getSessionCookie(headers, {
       cookieName: "session_data",
     });
-    if (shellStore.user && hasSessionDataCookie) {
+    if (shellStore.user && shellStore.organizationId && hasSessionDataCookie) {
       return;
     }
 
@@ -60,6 +62,13 @@ export const authService: AuthService = {
       redirectToSignIn();
       return;
     }
+
+    const organizationId = session.data.session.activeOrganizationId;
+    if (!organizationId) {
+      redirectToSignIn();
+      return;
+    }
+
     const user = session.data.user as User;
     const initialsSource = user?.name || user.email;
     const initialsSeparator = user?.name ? " " : "@";
@@ -69,23 +78,35 @@ export const authService: AuthService = {
       .join("");
 
     shellStore.user = user;
+    shellStore.userId = session.data.user.id;
+    shellStore.organizationId = organizationId;
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
     // Better Auth expects seconds.
     const expiresIn = Math.max(1, Math.floor(expiresInMs / 1000));
-    const { data, error } = await authClient.apiKey.create({ name, expiresIn });
+    const { data, error } = await authClient.apiKey.create({
+      name,
+      expiresIn,
+      organizationId: shellStore.organizationId,
+      metadata: { createdByUserId: shellStore.userId },
+    });
     if (error) throw new Error(error.message);
     return data as ApiKey;
   },
 
   async revokeApiKey(apiKeyId) {
-    const { error } = await authClient.apiKey.delete({ keyId: apiKeyId });
+    const { error } = await authClient.apiKey.delete({
+      keyId: apiKeyId,
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
   },
 
   async listApiKeys() {
-    const { data, error } = await authClient.apiKey.list();
+    const { data, error } = await authClient.apiKey.list({
+      organizationId: shellStore.organizationId,
+    });
     if (error) throw new Error(error.message);
     const keys = data.apiKeys.map((key) => ({
       ...key,
@@ -129,5 +150,7 @@ export const authService: AuthService = {
   async signOut() {
     await authClient.signOut();
     shellStore.user = undefined;
+    shellStore.userId = undefined;
+    shellStore.organizationId = undefined;
   },
 };

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -17,13 +17,15 @@ const apiKeys = new Collection({
 
 export const authService = {
   async ensureSignedIn() {
-    if (shellStore.user) return;
+    if (shellStore.user && shellStore.organizationId) return;
     shellStore.user = {
       name: "Dummy User",
       email: "dummy@user.com",
       initials: "DU",
       image: "",
     };
+    shellStore.userId = "dummy-user-id";
+    shellStore.organizationId = "dummy-org-id";
   },
 
   async generateApiKey(name, expiresInMs = DEFAULT_EXPIRATION_MS) {
@@ -58,5 +60,7 @@ export const authService = {
 
   async signOut() {
     shellStore.user = undefined;
+    shellStore.userId = undefined;
+    shellStore.organizationId = undefined;
   },
 } satisfies AuthService;

--- a/apps/console/app/lib/shell.ts
+++ b/apps/console/app/lib/shell.ts
@@ -14,8 +14,12 @@ export type Models = Record<
 
 export const shellStore = proxy<{
   user: User | undefined;
+  userId: string | undefined;
+  organizationId: string | undefined;
   models: Models | undefined;
 }>({
   user: undefined,
+  userId: undefined,
+  organizationId: undefined,
   models: undefined,
 });

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
@@ -74,7 +74,7 @@ export default function ApiKeysRoute({ loaderData }: Route.ComponentProps) {
       <div>
         <h1>API Keys</h1>
         <p className="text-sm text-muted-foreground">
-          Issue and revoke API keys to access your agent programmatically.
+          Manage organization API keys to access your agent programmatically.
         </p>
       </div>
 

--- a/packages/shared-api/middlewares/auth.ts
+++ b/packages/shared-api/middlewares/auth.ts
@@ -10,6 +10,12 @@ import { betterAuthCookieOptions } from "../lib/cookie-options";
 import type { Logger } from "./logging";
 
 const cookieConfig = getCookies(betterAuthCookieOptions);
+const verifyApiKeyUrl = new URL("/v1/api-key/verify", authUrl).toString();
+
+type VerifyApiKeyResult = {
+  valid: boolean;
+  key?: { userId: string; referenceId: string };
+};
 
 const createAuthClient = (request: Request) => {
   const headers = new Headers();
@@ -45,6 +51,31 @@ const createAuthClient = (request: Request) => {
   });
 };
 
+function extractBearerToken(authorization: string): string | null {
+  if (authorization.length < 8 || authorization.substring(0, 7).toLowerCase() !== "bearer ") return null;
+  return authorization.substring(7);
+}
+
+async function verifyApiKey(key: string): Promise<VerifyApiKeyResult | null> {
+  try {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    propagation.inject(context.active(), headers, {
+      set: (carrier, key, value) => {
+        carrier[key] = value;
+      },
+    });
+    const response = await fetch(verifyApiKeyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ key }),
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as VerifyApiKeyResult;
+  } catch {
+    return null;
+  }
+}
+
 export const authService = new Elysia({ name: "auth-service" })
   .resolve(async function resolveAuthContext(ctx) {
     const logger = (ctx as unknown as { logger: Logger }).logger;
@@ -57,48 +88,70 @@ export const authService = new Elysia({ name: "auth-service" })
 
     const authClient = createAuthClient(ctx.request);
 
-    let session, error;
-
+    // Cookie auth path
     if (cookie) {
-      session = await getCookieCache(ctx.request, {
+      const session = await getCookieCache(ctx.request, {
         secret: authSecret,
         isSecure: betterAuthCookieOptions.advanced.useSecureCookies,
       });
-    } else {
-      ({ data: session, error } = await authClient.getSession());
-    }
 
-    if (error || !session) {
-      logger.info({ error }, "Authentication failed or no credentials provided");
+      if (!session) {
+        logger.info("Cookie authentication failed");
+        const { attributes, name } = cookieConfig.sessionToken;
+        ctx.cookie[name] = {
+          value: "",
+          maxAge: 0,
+          ...attributes,
+        } as Cookie<string>;
 
-      // Clear the session cookie when unauthorized
-      const { attributes, name } = cookieConfig.sessionToken;
-      ctx.cookie[name] = {
-        value: "",
-        maxAge: 0,
-        ...attributes,
-      } as Cookie<string>;
+        return {
+          organizationId: undefined,
+          userId: undefined,
+          authClient,
+        } as const;
+      }
 
       return {
-        organizationId: undefined,
-        userId: undefined,
-        authClient: undefined,
+        organizationId: session.session.activeOrganizationId as string | undefined,
+        userId: session.user.id,
+        authClient,
       } as const;
     }
 
-    // For API key sessions, activeOrganizationId is missing (mock session bypasses hooks).
-    // Fall back to fetching from organization list.
-    let organizationId = session.session.activeOrganizationId;
-    if (!organizationId) {
-      const { data: orgs } = await authClient.organization.list();
-      if (orgs && orgs.length > 0) {
-        organizationId = orgs[0].id;
+    // API key auth path
+    if (authorization) {
+      const token = extractBearerToken(authorization);
+      if (!token) {
+        logger.info("Invalid authorization header format");
+        return {
+          organizationId: undefined,
+          userId: undefined,
+          authClient,
+        } as const;
       }
+
+      const result = await verifyApiKey(token);
+      if (!result?.valid || !result.key) {
+        logger.info("API key verification failed");
+        return {
+          organizationId: undefined,
+          userId: undefined,
+          authClient,
+        } as const;
+      }
+
+      // For org-owned keys, referenceId is the organization ID
+      return {
+        organizationId: result.key.referenceId,
+        userId: result.key.userId,
+        authClient,
+      } as const;
     }
 
+    // No credentials provided
     return {
-      organizationId,
-      userId: session.user.id,
+      organizationId: undefined,
+      userId: undefined,
       authClient,
     } as const;
   })


### PR DESCRIPTION
Switches API keys from user-scoped to organization-scoped using better-auth 1.5’s native org-owned key support. Addresses all code review comments.

- Pass `organizationId` to `apiKey.create/list/delete` in console client
- Replace `authClient.getSession()` with `fetch` to `/v1/api-key/verify` for API key auth
- Case-insensitive Bearer extraction via string ops (no regex)
- Always provide `authClient` in middleware for downstream org operations
- Wrap `verifyApiKey` in try/catch for network error resilience
- Store actual user ID in key metadata for audit
- Guard missing `organizationId` in `ensureSignedIn()`
- Remove fragile `organization.list()` fallback
- Remove `enableSessionForAPIKeys`
- Update UI copy

Closes #216

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys are now organization-scoped for better access control.
  * API key listing displays masked keys sorted by creation time.

* **Improvements**
  * Strengthened Bearer token validation in Authorization headers with case-insensitive matching.
  * Enhanced session authentication to require organization context for proper sign-in state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->