### PR TITLE
ci(claude): use dash branch prefix

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"
+          branch_prefix: "claude-"
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,LS,WebFetch,WebSearch


### PR DESCRIPTION
## Summary

- Set `branch_prefix` to `"claude-"` instead of the default `"claude/"` for cleaner branch names

## Test plan

- [ ] Trigger `@claude` on an issue and verify the created branch uses `claude-` prefix

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow configuration to enable branch-specific operations with standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->