### PR TITLE
ci(claude): increase max turns to 40

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,4 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,LS,WebFetch,WebSearch
-            --max-turns 30
+            --max-turns 40


### PR DESCRIPTION
Increase `--max-turns` from 30 to 40.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to enhance processing capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->