### PR TITLE
update docs link to new URL

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug._index/route.mdx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug._index/route.mdx
@@ -95,4 +95,4 @@ print(response.content)
 
 ## Next: Use your observability tools & evals as usual
 
-Continue to read our full documentation to [learn more](https://docs.hebo.ai/)
+Continue to read our full documentation to [learn more](https://hebo.ai/docs/introduction)


### PR DESCRIPTION
## Summary
- Updates the documentation link in the console onboarding page from `https://docs.hebo.ai/` to `https://hebo.ai/docs/introduction`

## Test plan
- [x] Verified no other references to the old URL exist in the codebase

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external documentation reference link to direct users to the new documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->