### PR TITLE
fix: validate model alias names to allow only safe characters

### DIFF
--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -42,7 +42,7 @@ export const Provider = t.Object({
 
 export const Models = t.Array(
   t.Object({
-    alias: t.String({ minLength: 1 }),
+    alias: t.String({ minLength: 1, pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$" }),
     // FUTURE: Add a validation for the model type
     type: t.String({ minLength: 1 }),
     // Inspired from Vercel Provider Options: https://vercel.com/docs/ai-gateway/provider-options

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/schema.ts
@@ -1,7 +1,15 @@
 import { z } from "zod";
 
+export const aliasPattern = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+
 export const modelConfigSchema = z.object({
-  alias: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a unique alias name"),
+  alias: ((msg) =>
+    z
+      .string(msg)
+      .trim()
+      .min(1, msg)
+      .regex(aliasPattern, "Alias must start with a letter or number and contain only letters, numbers, hyphens, and underscores")
+  )("Please enter a unique alias name"),
   type: ((msg) => z.string(msg).trim().min(1, msg))("Select one of the supported models"),
   routing: z
     .object({


### PR DESCRIPTION
Fix special character bypass in model alias name validation by adding regex validation (`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`) to both the console Zod schema and the API TypeBox schema.

Closes #232

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Strengthened alias field validation across the platform to enforce consistent naming conventions. Model aliases must now start with a letter or number and can only contain letters, numbers, hyphens, and underscores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->