### PR TITLE
fix: replace BYOK auto-state with inline notice to prevent card collapse

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -2,9 +2,10 @@ import { useForm, type FieldMetadata } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
 import { Brain, ChevronsUpDown, Edit, Info } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useFetcher } from "react-router";
+import { Link, useFetcher } from "react-router";
 import { useSnapshot } from "valtio";
 
+import { Alert, AlertDescription } from "@hebo/shared-ui/components/Alert";
 import { Badge } from "@hebo/shared-ui/components/Badge";
 import { Button } from "@hebo/shared-ui/components/Button";
 import { Card, CardContent, CardFooter, CardHeader } from "@hebo/shared-ui/components/Card";
@@ -35,7 +36,6 @@ import {
   FieldDescription,
   FormControl,
 } from "@hebo/shared-ui/components/Field";
-import { Alert, AlertDescription } from "@hebo/shared-ui/components/Alert";
 import { Input } from "@hebo/shared-ui/components/Input";
 import { Select } from "@hebo/shared-ui/components/Select";
 import { Separator } from "@hebo/shared-ui/components/Separator";
@@ -165,10 +165,8 @@ function ModelCard(props: {
   const isByokRequired = selectedModel?.requiresByok === true;
   const availableProviders = providers.filter((p) => selectedModel?.providers?.includes(p.slug));
 
-  const [advancedOpen, setAdvancedOpen] = useState(isByokRequired);
-  const [routingEnabled, setRoutingEnabled] = useState(
-    Boolean(model.getFieldset().routing.value),
-  );
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [routingEnabled, setRoutingEnabled] = useState(Boolean(model.getFieldset().routing.value));
 
   const aliasPath = [agentSlug, branchSlug, model.getFieldset().alias.value || "alias"].join("/");
 
@@ -238,8 +236,14 @@ function ModelCard(props: {
               <Alert>
                 <Info className="size-4" />
                 <AlertDescription>
-                  This model requires your own provider key. Enable "Bring Your Own Provider" below
-                  and select a configured provider.
+                  This model requires your own provider key. Configure one on the{" "}
+                  <Link
+                    to={`/agent/${agentSlug}/branch/${branchSlug}/providers`}
+                    className="underline"
+                  >
+                    Providers page
+                  </Link>
+                  , then slect it in "Advanced options" -&gt; "Bring Your Own Provider".
                 </AlertDescription>
               </Alert>
             )}
@@ -269,31 +273,41 @@ function ModelCard(props: {
                   <FieldContent>
                     <FieldLabel htmlFor={`byo-${aliasPath}`}>Bring Your Own Provider</FieldLabel>
                     <FieldDescription>
-                      Route requests through your own provider credentials.
-                      {isByokRequired && " Required for this model."}
+                      Route requests through your own{" "}
+                      <Link
+                        to={`/agent/${agentSlug}/branch/${branchSlug}/providers`}
+                        className="underline"
+                      >
+                        provider credentials
+                      </Link>
+                      .
                     </FieldDescription>
                   </FieldContent>
-                  {routingEnabled && (
-                    <Field
-                      name={`${model.getFieldset().routing.getFieldset().only.name}[0]`}
-                      className="max-w-44"
-                    >
-                      <FieldControl>
-                        <Select
-                          items={availableProviders.map((provider) => ({
-                            value: provider.slug,
-                            label: provider.name,
-                          }))}
-                          placeholder={
-                            availableProviders.length > 0
-                              ? "Select provider"
-                              : "No providers configured"
-                          }
-                          aria-label="Select Provider"
-                        />
-                      </FieldControl>
-                    </Field>
-                  )}
+                  <Field
+                    name={`${model.getFieldset().routing.getFieldset().only.name}[0]`}
+                    className="max-w-44"
+                  >
+                    <FieldControl>
+                      <Select
+                        items={
+                          availableProviders.length > 0
+                            ? availableProviders.map((provider) => ({
+                                value: provider.slug,
+                                label: provider.name,
+                              }))
+                            : [
+                                {
+                                  value: "__none__",
+                                  label: "No providers configured",
+                                  disabled: true,
+                                },
+                              ]
+                        }
+                        placeholder="Select provider"
+                        aria-label="Select Provider"
+                      />
+                    </FieldControl>
+                  </Field>
                 </Field>
               </CollapsibleContent>
             </Collapsible>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -232,7 +232,7 @@ function ModelCard(props: {
               </Field>
             </FieldGroup>
 
-            {isByokRequired && !routingEnabled && (
+            {isByokRequired && (
               <Alert>
                 <Info className="size-4" />
                 <AlertDescription>
@@ -287,7 +287,7 @@ function ModelCard(props: {
                     name={`${model.getFieldset().routing.getFieldset().only.name}[0]`}
                     className="max-w-44"
                   >
-                    <FieldControl>
+                    <FieldControl disabled={!routingEnabled}>
                       <Select
                         items={
                           availableProviders.length > 0

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -1,6 +1,6 @@
 import { useForm, type FieldMetadata } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
-import { Brain, ChevronsUpDown, Edit } from "lucide-react";
+import { Brain, ChevronsUpDown, Edit, Info } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import { useSnapshot } from "valtio";
@@ -35,6 +35,7 @@ import {
   FieldDescription,
   FormControl,
 } from "@hebo/shared-ui/components/Field";
+import { Alert, AlertDescription } from "@hebo/shared-ui/components/Alert";
 import { Input } from "@hebo/shared-ui/components/Input";
 import { Select } from "@hebo/shared-ui/components/Select";
 import { Separator } from "@hebo/shared-ui/components/Separator";
@@ -164,21 +165,10 @@ function ModelCard(props: {
   const isByokRequired = selectedModel?.requiresByok === true;
   const availableProviders = providers.filter((p) => selectedModel?.providers?.includes(p.slug));
 
-  // BUG: auto-setting state for BYOK models renders a phantom routing input via
-  // keepMounted, causing a Conform form.dirty false positive that triggers the
-  // reset → submit → auto-close cascade when opening any card.
-  // const [advancedOpen, setAdvancedOpen] = useState(isByokRequired);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(isByokRequired);
   const [routingEnabled, setRoutingEnabled] = useState(
-    // isByokRequired || Boolean(model.getFieldset().routing.value),
     Boolean(model.getFieldset().routing.value),
   );
-  // useEffect(() => {
-  //   if (isByokRequired) {
-  //     setAdvancedOpen(true);
-  //     setRoutingEnabled(true);
-  //   }
-  // }, [isByokRequired]);
 
   const aliasPath = [agentSlug, branchSlug, model.getFieldset().alias.value || "alias"].join("/");
 
@@ -244,6 +234,16 @@ function ModelCard(props: {
               </Field>
             </FieldGroup>
 
+            {isByokRequired && !routingEnabled && (
+              <Alert>
+                <Info className="size-4" />
+                <AlertDescription>
+                  This model requires your own provider key. Enable "Bring Your Own Provider" below
+                  and select a configured provider.
+                </AlertDescription>
+              </Alert>
+            )}
+
             <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
               <div className="flex items-center gap-1">
                 <h4 className="text-sm font-medium">Advanced options</h4>
@@ -264,36 +264,36 @@ function ModelCard(props: {
                   <Checkbox
                     id={`byo-${aliasPath}`}
                     checked={routingEnabled}
-                    onCheckedChange={isByokRequired ? undefined : setRoutingEnabled}
-                    disabled={isByokRequired}
+                    onCheckedChange={setRoutingEnabled}
                   />
                   <FieldContent>
                     <FieldLabel htmlFor={`byo-${aliasPath}`}>Bring Your Own Provider</FieldLabel>
                     <FieldDescription>
-                      {isByokRequired
-                        ? "This model requires your own provider key."
-                        : "Setup your credentials first in providers settings"}
+                      Route requests through your own provider credentials.
+                      {isByokRequired && " Required for this model."}
                     </FieldDescription>
                   </FieldContent>
-                  <Field
-                    name={`${model.getFieldset().routing.getFieldset().only.name}[0]`}
-                    className="max-w-44"
-                  >
-                    <FieldControl disabled={!routingEnabled}>
-                      <Select
-                        items={availableProviders.map((provider) => ({
-                          value: provider.slug,
-                          label: provider.name,
-                        }))}
-                        placeholder={
-                          availableProviders.length > 0
-                            ? "Select provider"
-                            : "No providers configured"
-                        }
-                        aria-label="Select Provider"
-                      />
-                    </FieldControl>
-                  </Field>
+                  {routingEnabled && (
+                    <Field
+                      name={`${model.getFieldset().routing.getFieldset().only.name}[0]`}
+                      className="max-w-44"
+                    >
+                      <FieldControl>
+                        <Select
+                          items={availableProviders.map((provider) => ({
+                            value: provider.slug,
+                            label: provider.name,
+                          }))}
+                          placeholder={
+                            availableProviders.length > 0
+                              ? "Select provider"
+                              : "No providers configured"
+                          }
+                          aria-label="Select Provider"
+                        />
+                      </FieldControl>
+                    </Field>
+                  )}
                 </Field>
               </CollapsibleContent>
             </Collapsible>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -243,7 +243,7 @@ function ModelCard(props: {
                   >
                     Providers page
                   </Link>
-                  , then select it in "Advanced options" -&gt; "Bring Your Own Provider".
+                  , then select it in "Advanced options" → "Bring Your Own Provider".
                 </AlertDescription>
               </Alert>
             )}

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -243,7 +243,7 @@ function ModelCard(props: {
                   >
                     Providers page
                   </Link>
-                  , then slect it in "Advanced options" -&gt; "Bring Your Own Provider".
+                  , then select it in "Advanced options" -&gt; "Bring Your Own Provider".
                 </AlertDescription>
               </Alert>
             )}

--- a/packages/shared-ui/src/components/Select.tsx
+++ b/packages/shared-ui/src/components/Select.tsx
@@ -7,7 +7,7 @@ import {
 } from "#/_shadcn/ui/select";
 
 type SelectProps = React.ComponentProps<typeof ShadCnSelect> & {
-  items: Array<{ value: string; label: React.ReactNode }>;
+  items: Array<{ value: string; label: React.ReactNode; disabled?: boolean }>;
   placeholder?: string;
 };
 
@@ -26,7 +26,7 @@ function Select({ items, placeholder, ...props }: SelectProps) {
       <SelectContent>
         {items.map((item) => {
           return (
-            <SelectItem key={item.value} value={item.value}>
+            <SelectItem key={item.value} value={item.value} disabled={item.disabled}>
               {item.label}
             </SelectItem>
           );


### PR DESCRIPTION
Closes #243

Replaces the automatic BYOK checkbox/advanced-section state initialization with an inline Alert notice, fixing the model config card collapse bug.

## Changes

- Add inline Alert when BYOK model has no provider configured
- Conditionally render routing field only when checkbox is checked (prevents phantom DOM inputs)
- Auto-open advanced section for BYOK models (safe without phantom field)
- Remove disabled/locked checkbox behavior
- Clean up commented-out bug workaround code

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline alerts for models requiring Bring Your Own Key (BYOK), now shown in multiple card views with links to provider setup.
  * Provider selector always shows a placeholder and displays a disabled "No providers configured" option when applicable.

* **Improvements**
  * Select control supports per-item disabled states for finer UX control.
  * Routing toggle now applies immediately when changed; provider credential references include direct navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->