### PR TITLE
fix: resolve hydration error on Overview page

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug._index/route.mdx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug._index/route.mdx
@@ -5,9 +5,11 @@ import { kbs } from "~console/lib/utils";
 
 <Logo className="hidden md:flex" />
 
-<p className="text-base font-semibold">
-  Hi <UserName />!
-</p>
+<div className="text-base font-semibold">
+
+Hi <UserName />!
+
+</div>
 
 Start using our interactive playground ({kbs("mod+P")}) or code your first agent with our gateway.
 


### PR DESCRIPTION
Fix hydration error caused by nested `<p>` tags in the Overview page MDX.

The MDX compiler wraps inline text in `<p>` tags, which created an invalid `<p>` inside `<p>` nesting. Changed the outer element to a `<div>`.

Closes #249

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor structural updates to the greeting section layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->