### PR TITLE
fix: map user image from session to show GitHub avatar in user menu

### DIFF
--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -74,6 +74,7 @@ export const authService: AuthService = {
       email: session.data.user.email,
       userId: session.data.user.id,
       organizationId: session.data.session.activeOrganizationId!,
+      image: session.data.user.image ?? undefined,
     };
 
     user.initials = (user?.name ?? user.email)


### PR DESCRIPTION
Adds the missing `image` field to the `User` object constructed in `ensureSignedIn`, so OAuth provider avatars (GitHub, Google) are forwarded to the shell store and displayed in the sidebar user menu.

Closes #256

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles now include support for displaying user images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->