### PR TITLE
fix: show Embeddings badge and shorten Nova name in model selector

### DIFF
--- a/apps/console/app/components/ui/ModelSelector.tsx
+++ b/apps/console/app/components/ui/ModelSelector.tsx
@@ -22,7 +22,7 @@ function ModelSelector({ models, ...props }: ModelSelectorProps) {
             ) : m.requiresByok ? (
               <Badge className="bg-amber-600 text-white!">BYOK</Badge>
             ) : null}
-            {m.modality === "embeddings" && (
+            {m.modality === "embedding" && (
               <Badge className="bg-blue-500 text-white!">Embeddings</Badge>
             )}
           </>

--- a/apps/console/app/lib/shell.ts
+++ b/apps/console/app/lib/shell.ts
@@ -6,7 +6,7 @@ export type Models = Record<
   string,
   {
     name: string;
-    modality: string;
+    modality: "chat" | "embedding";
     providers: readonly string[];
     free: boolean;
     requiresByok: boolean;

--- a/apps/console/app/mocks/routes/models.ts
+++ b/apps/console/app/mocks/routes/models.ts
@@ -35,11 +35,11 @@ const SUPPORTED_MODELS = [
   },
   {
     type: "amazon/nova-2-multimodal-embeddings",
-    displayName: "Amazon Nova 2 Multimodal Embeddings",
+    displayName: "Nova 2 Embeddings",
     owner: "amazon",
     created: 1_764_888_221,
     providers: [{ bedrock: "amazon.nova-2-multimodal-embeddings-v1:0" }],
-    modality: "embeddings",
+    modality: "embedding",
     free: true,
   },
   {
@@ -52,7 +52,7 @@ const SUPPORTED_MODELS = [
         voyage: "voyage-3.5",
       },
     ],
-    modality: "embeddings",
+    modality: "embedding",
     free: false,
   },
 ] as const;

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -24,7 +24,7 @@
     "@elysiajs/cors": "catalog:",
     "@elysiajs/openapi": "catalog:",
     "@elysiajs/opentelemetry": "catalog:",
-    "@hebo-ai/gateway": "0.8.0-rc2",
+    "@hebo-ai/gateway": "0.8.0-rc3",
     "@hebo/api": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -125,7 +125,7 @@
         "@elysiajs/cors": "catalog:",
         "@elysiajs/openapi": "catalog:",
         "@elysiajs/opentelemetry": "catalog:",
-        "@hebo-ai/gateway": "0.8.0-rc2",
+        "@hebo-ai/gateway": "0.8.0-rc3",
         "@hebo/api": "workspace:*",
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
@@ -549,7 +549,7 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.8.0-rc2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "lru-cache": "^11.2.6", "uuid": "^13.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google": "^3.0.43", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@libsql/client": "^0.14.0", "@opentelemetry/api": "^1.9.0", "better-sqlite3": "^11.0.0", "mysql2": "^3.11.0", "pg": "^8.13.0", "postgres": "^3.4.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider"] }, "sha512-2T/sz0hgwmfvM80szU43EDuQUjtlK8djPuXr2Pxe79MpqphVN3xNMIZX1GFR/G2IQSmofD52M1Ko4FpUaIPLPQ=="],
+    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.8.0-rc3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "lru-cache": "^11.2.6", "uuid": "^13.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google": "^3.0.43", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@libsql/client": "^0.14.0", "@opentelemetry/api": "^1.9.0", "better-sqlite3": "^11.0.0", "mysql2": "^3.11.0", "pg": "^8.13.0", "postgres": "^3.4.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider"] }, "sha512-tdoo5ArMz6Czn21MjfNkXTpI1BBa2TlrVhhKGbs7WAYqaxXDi7etz0b0IDXfJP+lLr80mk9PzCiYnNuw1PHtqg=="],
 
     "@hebo/aikit-ui": ["@hebo/aikit-ui@workspace:packages/aikit-ui"],
 


### PR DESCRIPTION
Two small cosmetic fixes to the model type selector.

- Update `@hebo-ai/gateway` to `0.8.0-rc3` (upstream Nova naming fix)
- Match gateway's `"embedding"` (singular) value in ModelSelector and mocks
- Narrow the `modality` type in `Models`
- Update Nova mock displayName to "Nova 2 Embeddings"

Closes #254

Generated with [Claude Code](https://claude.ai/code)