### PR TITLE
Replace horizontal tag scrolling with hover card reveal in traces list

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
@@ -5,7 +5,11 @@ import { useLocation } from "react-router";
 import { Badge } from "@hebo/shared-ui/components/Badge";
 import { Button } from "@hebo/shared-ui/components/Button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@hebo/shared-ui/components/Empty";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@hebo/shared-ui/components/HoverCard";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@hebo/shared-ui/components/HoverCard";
 import { Input } from "@hebo/shared-ui/components/Input";
 import { Label } from "@hebo/shared-ui/components/Label";
 import {
@@ -200,30 +204,34 @@ function TagStrip({ metadata }: { metadata: Record<string, string> }) {
   const visible = entries.slice(0, VISIBLE_TAG_COUNT);
   const overflowCount = entries.length - visible.length;
 
-  const visibleTags = visible.map(([key, value]) => (
-    <Badge key={key} variant="secondary" className="shrink-0 bg-muted text-muted-foreground">
-      {key}: {value}
-    </Badge>
-  ));
-
-  if (overflowCount <= 0) {
-    return <div className="flex items-center gap-1.5 overflow-hidden">{visibleTags}</div>;
-  }
-
   return (
-    <HoverCard delay={150} closeDelay={100}>
+    <HoverCard>
       <HoverCardTrigger
+        delay={150}
+        closeDelay={100}
         render={
           <div className="flex items-center gap-1.5 overflow-hidden">
-            {visibleTags}
-            <span className="shrink-0 text-xs text-muted-foreground">+{overflowCount}</span>
+            <div className="flex min-w-0 flex-1 items-center gap-1.5 mask-[linear-gradient(to_right,black_calc(100%-3rem),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%-3rem),transparent)]">
+              {visible.map(([key, value]) => (
+                <Badge
+                  key={key}
+                  variant="secondary"
+                  className="shrink-0 bg-muted text-muted-foreground"
+                >
+                  {key}: {value}
+                </Badge>
+              ))}
+            </div>
+            {overflowCount > 0 && (
+              <span className="shrink-0 text-xs text-muted-foreground">+{overflowCount}</span>
+            )}
           </div>
         }
       />
-      <HoverCardContent align="start" className="w-auto max-w-xs">
-        <div className="flex flex-wrap gap-1.5">
+      <HoverCardContent align="start" className="w-auto">
+        <div className="flex flex-col gap-1.5">
           {entries.map(([key, value]) => (
-            <Badge key={key} variant="secondary" className="bg-muted text-muted-foreground">
+            <Badge key={key} variant="secondary" className="w-fit bg-muted text-muted-foreground">
               {key}: {value}
             </Badge>
           ))}

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "react-router";
 import { Badge } from "@hebo/shared-ui/components/Badge";
 import { Button } from "@hebo/shared-ui/components/Button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@hebo/shared-ui/components/Empty";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@hebo/shared-ui/components/HoverCard";
 import { Input } from "@hebo/shared-ui/components/Input";
 import { Label } from "@hebo/shared-ui/components/Label";
 import {
@@ -153,17 +154,7 @@ export function TraceList({
                       )}
 
                       {Object.keys(trace.metadata).length > 0 && (
-                        <div className="flex w-full items-center gap-1.5 overflow-x-auto">
-                          {Object.entries(trace.metadata).map(([key, value]) => (
-                            <Badge
-                              key={key}
-                              variant="secondary"
-                              className="bg-muted text-muted-foreground"
-                            >
-                              {key}: {value}
-                            </Badge>
-                          ))}
-                        </div>
+                        <TagStrip metadata={trace.metadata} />
                       )}
                     </button>
                   );
@@ -199,6 +190,46 @@ export function TraceList({
         )}
       </div>
     </div>
+  );
+}
+
+const VISIBLE_TAG_COUNT = 3;
+
+function TagStrip({ metadata }: { metadata: Record<string, string> }) {
+  const entries = Object.entries(metadata);
+  const visible = entries.slice(0, VISIBLE_TAG_COUNT);
+  const overflowCount = entries.length - visible.length;
+
+  const visibleTags = visible.map(([key, value]) => (
+    <Badge key={key} variant="secondary" className="shrink-0 bg-muted text-muted-foreground">
+      {key}: {value}
+    </Badge>
+  ));
+
+  if (overflowCount <= 0) {
+    return <div className="flex items-center gap-1.5 overflow-hidden">{visibleTags}</div>;
+  }
+
+  return (
+    <HoverCard delay={150} closeDelay={100}>
+      <HoverCardTrigger
+        render={
+          <div className="flex items-center gap-1.5 overflow-hidden">
+            {visibleTags}
+            <span className="shrink-0 text-xs text-muted-foreground">+{overflowCount}</span>
+          </div>
+        }
+      />
+      <HoverCardContent align="start" className="w-auto max-w-xs">
+        <div className="flex flex-wrap gap-1.5">
+          {entries.map(([key, value]) => (
+            <Badge key={key} variant="secondary" className="bg-muted text-muted-foreground">
+              {key}: {value}
+            </Badge>
+          ))}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   );
 }
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
@@ -207,7 +207,7 @@ function TagStrip({ metadata }: { metadata: Record<string, string> }) {
   return (
     <HoverCard>
       <HoverCardTrigger
-        delay={150}
+        delay={250}
         closeDelay={100}
         render={
           <div className="flex items-center gap-1.5 overflow-hidden">
@@ -228,15 +228,17 @@ function TagStrip({ metadata }: { metadata: Record<string, string> }) {
           </div>
         }
       />
-      <HoverCardContent align="start" className="w-auto">
-        <div className="flex flex-col gap-1.5">
-          {entries.map(([key, value]) => (
-            <Badge key={key} variant="secondary" className="w-fit bg-muted text-muted-foreground">
-              {key}: {value}
-            </Badge>
-          ))}
-        </div>
-      </HoverCardContent>
+      {entries.length >= VISIBLE_TAG_COUNT && (
+        <HoverCardContent align="start" className="w-auto">
+          <div className="flex flex-col gap-1.5">
+            {entries.map(([key, value]) => (
+              <Badge key={key} variant="secondary" className="w-fit bg-muted text-muted-foreground">
+                {key}: {value}
+              </Badge>
+            ))}
+          </div>
+        </HoverCardContent>
+      )}
     </HoverCard>
   );
 }

--- a/apps/console/app/routes/_shell.agent.create/form.tsx
+++ b/apps/console/app/routes/_shell.agent.create/form.tsx
@@ -44,9 +44,13 @@ export function AgentCreateForm() {
     constraint: getZodConstraint(AgentCreateSchema),
     defaultValue: {
       defaultModel: (function selectDefaultModel() {
-        return Object.entries(models ?? {}).toSorted(
-          ([, a], [, b]) => Number(b.free) - Number(a.free) || a.name.localeCompare(b.name),
-        )[0]?.[0];
+        return Object.entries(models ?? {})
+          .filter(([, m]) => m.modality !== "embedding")
+          .toSorted(
+            ([, a], [, b]) =>
+              Number(b.free) - Number(a.free) ||
+              a.name.localeCompare(b.name, undefined, { numeric: true }),
+          )[0]?.[0];
       })(),
     },
   });

--- a/packages/shared-ui/src/_shadcn/ui/hover-card.tsx
+++ b/packages/shared-ui/src/_shadcn/ui/hover-card.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card"
+
+import { cn } from "#/lib/utils"
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+  return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({ ...props }: PreviewCardPrimitive.Trigger.Props) {
+  return (
+    <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 4,
+  ...props
+}: PreviewCardPrimitive.Popup.Props &
+  Pick<
+    PreviewCardPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+      <PreviewCardPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PreviewCardPrimitive.Popup
+          data-slot="hover-card-content"
+          className={cn(
+            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/packages/shared-ui/src/components/HoverCard.tsx
+++ b/packages/shared-ui/src/components/HoverCard.tsx
@@ -1,0 +1,1 @@
+export { HoverCard, HoverCardContent, HoverCardTrigger } from "#/_shadcn/ui/hover-card";


### PR DESCRIPTION
Replaces horizontal tag scrolling in the traces list with a collapsed tag strip + hover card reveal pattern.

- Shows first 3 tags inline with +N overflow indicator
- HoverCard reveals all tags on hover (150ms delay, 100ms close)
- No horizontal scrolling, no click interaction required

Closes #261

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a HoverCard UI for hover-to-reveal supplementary content.
  * Trace list metadata now displays as compact badges (up to 3) with a +N overflow indicator and hover-to-view-all behavior.

* **Improvements**
  * Default model suggestion in the create form excludes embedding models and resolves ties using numeric-aware name ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->