### PR TITLE
perf: parallelize independent fetches in shell clientLoader

### DIFF
--- a/apps/console/app/routes/_shell/route.tsx
+++ b/apps/console/app/routes/_shell/route.tsx
@@ -40,30 +40,30 @@ async function authMiddleware() {
 export const clientMiddleware = [authMiddleware];
 
 export async function clientLoader() {
-  const agents = await api.agents.get();
-
-  if (!shellStore.models) {
-    try {
-      const models = await gateway.models.get({ query: { endpoints: true } });
-
-      const supportedModels = Object.fromEntries(
-        (models.data?.data ?? []).map((m) => [
-          m.id,
-          {
-            name: m.name,
-            modality: m.architecture.output_modalities[0],
-            providers: m.endpoints?.map((e) => e.tag) ?? [],
-            free: m.free === true,
-            requiresByok: m.requiresByok === true,
-          },
-        ]),
-      );
-
-      shellStore.models = supportedModels;
-    } catch {
-      // Non-fatal — models will be fetched on next navigation
-    }
-  }
+  const [agents] = await Promise.all([
+    api.agents.get(),
+    shellStore.models
+      ? Promise.resolve()
+      : gateway.models
+          .get({ query: { endpoints: true } })
+          .then((models) => {
+            shellStore.models = Object.fromEntries(
+              (models.data?.data ?? []).map((m) => [
+                m.id,
+                {
+                  name: m.name,
+                  modality: m.architecture.output_modalities[0],
+                  providers: m.endpoints?.map((e) => e.tag) ?? [],
+                  free: m.free === true,
+                  requiresByok: m.requiresByok === true,
+                },
+              ]),
+            );
+          })
+          .catch(() => {
+            // Non-fatal — models will be fetched on next navigation
+          }),
+  ]);
 
   return { agents: agents?.data ?? [] };
 }


### PR DESCRIPTION
Use `Promise.all()` to run the agents and models API calls concurrently instead of sequentially in the shell `clientLoader`. The two fetches are independent — neither needs the other’s result — so parallel execution reduces shell layout load latency.

Closes #265

Generated with [Claude Code](https://claude.ai/code)