### PR TITLE
perf: combine chained filter().map() in mock and auth helpers

### DIFF
--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -122,26 +122,32 @@ export const authService = {
   async getOrganization() {
     const organizationId = shellStore.user?.organizationId;
     return {
-      members: members
-        .findMany()
-        .filter((m) => m.organizationId === organizationId)
-        .map((m) => ({
-          id: m.id,
-          userId: m.userId,
-          role: m.role,
-          createdAt: m.createdAt,
-          user: { name: m.userName, email: m.userEmail },
-        })),
-      invitations: invitations
-        .findMany()
-        .filter((i) => i.organizationId === organizationId)
-        .map((i) => ({
-          id: i.id,
-          email: i.email,
-          role: i.role,
-          expiresAt: i.expiresAt,
-          status: i.status,
-        })),
+      members: members.findMany().flatMap((m) =>
+        m.organizationId === organizationId
+          ? [
+              {
+                id: m.id,
+                userId: m.userId,
+                role: m.role,
+                createdAt: m.createdAt,
+                user: { name: m.userName, email: m.userEmail },
+              },
+            ]
+          : [],
+      ),
+      invitations: invitations.findMany().flatMap((i) =>
+        i.organizationId === organizationId
+          ? [
+              {
+                id: i.id,
+                email: i.email,
+                role: i.role,
+                expiresAt: i.expiresAt,
+                status: i.status,
+              },
+            ]
+          : [],
+      ),
     };
   },
 

--- a/apps/console/app/mocks/routes/traces.ts
+++ b/apps/console/app/mocks/routes/traces.ts
@@ -548,13 +548,13 @@ export const traceHandlers = [
       }
 
       // Apply metadata filters
-      let filtered = [...mockTraces];
-      for (const [metaKey, value] of Object.entries(metadataFilters)) {
-        filtered = filtered.filter((t) => {
-          const detail = mockSpanDetails[t.traceId] as any;
-          return detail?.metadata?.[metaKey] === value;
-        });
-      }
+      const filterEntries = Object.entries(metadataFilters);
+      const filtered = filterEntries.length
+        ? mockTraces.filter((t) => {
+            const detail = mockSpanDetails[t.traceId] as any;
+            return filterEntries.every(([metaKey, value]) => detail?.metadata?.[metaKey] === value);
+          })
+        : [...mockTraces];
 
       const start = (page - 1) * pageSize;
       const paged = filtered.slice(start, start + pageSize);


### PR DESCRIPTION
Combine chained array operations for better performance:

- Use `flatMap` instead of `filter().map()` in `dummy-auth.ts`
- Use single `.filter()` with `.every()` instead of nested filter loop in `traces.ts`

Closes #267

Generated with [Claude Code](https://claude.ai/code)