### PR TITLE
fix: return { intent, submission } from multi-action route clientActions

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.api-keys/route.tsx
@@ -26,7 +26,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         schema: ApiKeyCreateSchema,
       });
 
-      if (submission.status !== "success") return { submission: submission.reply() };
+      if (submission.status !== "success") return { intent, submission: submission.reply() };
 
       let apiKey;
       try {
@@ -37,13 +37,14 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         );
       } catch (error) {
         return {
+          intent,
           submission: submission.reply({
             formErrors: [parseError(error).message],
           }),
         };
       }
 
-      return { submission: submission.reply({ resetForm: true }), apiKey };
+      return { intent, submission: submission.reply({ resetForm: true }), apiKey };
     }
 
     case "revoke": {
@@ -51,19 +52,20 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         schema: ApiKeyRevokeSchema,
       });
 
-      if (submission.status !== "success") return { submission: submission.reply() };
+      if (submission.status !== "success") return { intent, submission: submission.reply() };
 
       try {
         await authService.revokeApiKey(submission.value.apiKeyId);
       } catch (error) {
         return {
+          intent,
           submission: submission.reply({
             formErrors: [parseError(error).message],
           }),
         };
       }
 
-      return { submission: submission.reply() };
+      return { intent, submission: submission.reply() };
     }
   }
 }

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/route.tsx
@@ -22,7 +22,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         schema: ProviderConfigureSchema,
       });
 
-      if (submission.status !== "success") return { submission: submission.reply() };
+      if (submission.status !== "success") return { intent, submission: submission.reply() };
 
       let provider;
       try {
@@ -31,13 +31,14 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         });
       } catch (error) {
         return {
+          intent,
           submission: submission.reply({
             formErrors: [parseError(error).message],
           }),
         };
       }
 
-      return { submission: submission.reply(), provider };
+      return { intent, submission: submission.reply(), provider };
     }
 
     case "clear": {
@@ -45,19 +46,20 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
         schema: CredentialsClearSchema,
       });
 
-      if (submission.status !== "success") return { submission: submission.reply() };
+      if (submission.status !== "success") return { intent, submission: submission.reply() };
 
       try {
         await api.providers({ slug: submission.value.providerSlug }).config.delete();
       } catch (error) {
         return {
+          intent,
           submission: submission.reply({
             formErrors: [parseError(error).message],
           }),
         };
       }
 
-      return { submission: submission.reply() };
+      return { intent, submission: submission.reply() };
     }
   }
 }

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/create.tsx
@@ -45,7 +45,7 @@ type CreateBranchProps = {
 export default function CreateBranch({ branches }: CreateBranchProps) {
   const fetcher = useFetcher();
   const [form, fields] = useForm<BranchCreateFormValues>({
-    lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
+    lastResult: fetcher.state === "idle" ? fetcher.data?.submission : undefined,
     constraint: getZodConstraint(BranchCreateSchema),
     defaultValue: {
       sourceBranchSlug: branches[0].slug,

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/delete.tsx
@@ -41,7 +41,7 @@ export default function DeleteBranchDialog({ branchSlug, ...props }: DeleteBranc
   const fetcher = useFetcher();
   const [form, fields] = useForm<BranchDeleteFormValues>({
     id: branchSlug,
-    lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
+    lastResult: fetcher.state === "idle" ? fetcher.data?.submission : undefined,
     constraint: getZodConstraint(createBranchDeleteSchema(branchSlug)),
     defaultValue: { branchSlug },
   });

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branches/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branches/route.tsx
@@ -21,7 +21,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         schema: BranchCreateSchema,
       });
 
-      if (submission!.status !== "success") return submission!.reply();
+      if (submission!.status !== "success")
+        return { intent, submission: submission!.reply() };
 
       try {
         result = await api
@@ -33,13 +34,21 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
             sourceBranchSlug: submission.value.sourceBranchSlug,
           });
       } catch (error) {
-        return submission.reply({ formErrors: [parseError(error).message] });
+        return {
+          intent,
+          submission: submission.reply({ formErrors: [parseError(error).message] }),
+        };
       }
 
       if (result.error?.status === 409 || result.error?.status === 404)
-        return submission.reply({ fieldErrors: { branchName: [String(result.error.value)] } });
+        return {
+          intent,
+          submission: submission.reply({
+            fieldErrors: { branchName: [String(result.error.value)] },
+          }),
+        };
 
-      return submission.reply({ resetForm: true });
+      return { intent, submission: submission.reply({ resetForm: true }) };
     }
 
     case "delete": {
@@ -47,7 +56,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         schema: createBranchDeleteSchema(formData.get("branchSlug") as string),
       });
 
-      if (submission!.status !== "success") return submission!.reply();
+      if (submission!.status !== "success")
+        return { intent, submission: submission!.reply() };
 
       try {
         result = await api
@@ -55,13 +65,21 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           .branches({ branchSlug: submission.value.branchSlug })
           .delete();
       } catch (error) {
-        return submission.reply({ formErrors: [parseError(error).message] });
+        return {
+          intent,
+          submission: submission.reply({ formErrors: [parseError(error).message] }),
+        };
       }
 
       if (result.error)
-        return submission.reply({ fieldErrors: { slugConfirm: [String(result.error.value)] } });
+        return {
+          intent,
+          submission: submission.reply({
+            fieldErrors: { slugConfirm: [String(result.error.value)] },
+          }),
+        };
 
-      return submission.reply();
+      return { intent, submission: submission.reply() };
     }
   }
 }


### PR DESCRIPTION
Align branches, api-keys, and providers routes with the AGENTS.md convention for multiple actions in one route. Each `clientAction` branch now returns `{ intent, submission: submission.reply() }` so consumers can filter `lastResult` by intent, preventing cross-intent bleed.

Closes #269

Generated with [Claude Code](https://claude.ai/code)