### PR TITLE
cache metadata column names with lru-cache (2s TTL)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,8 @@
     "@elysiajs/opentelemetry": "catalog:",
     "@hebo/shared-api": "workspace:*",
     "@prisma/client": "catalog:",
-    "elysia": "catalog:"
+    "elysia": "catalog:",
+    "lru-cache": "catalog:"
   },
   "devDependencies": {
     "@hebo/typescript-config": "workspace:*",

--- a/apps/api/src/modules/traces/service.ts
+++ b/apps/api/src/modules/traces/service.ts
@@ -1,3 +1,5 @@
+import { LRUCache } from "lru-cache";
+
 import type { GreptimeDb } from "~api/middleware/greptime";
 
 import type { GenAIFinishReasons, GenAIInputMessages, GenAIOutputMessages } from "./types";
@@ -13,8 +15,14 @@ import {
 
 const METADATA_PREFIX = "span_attributes.gen_ai.request.metadata.";
 
-// FUTURE: cache this
+const metadataColumnsCache = new LRUCache<string, Array<{ column_name: unknown }>>({
+  max: 1,
+  ttl: 2_000,
+});
+
 async function getMetadataColumnNames(greptimeDb: GreptimeDb) {
+  const cached = metadataColumnsCache.get("metadata_columns");
+  if (cached) return cached;
   // Workaround: values inlined instead of using $1 params due to GreptimeDB cluster-mode bug.
   // See: https://github.com/GreptimeTeam/greptimedb/issues/7819
   // Parametrized version to restore once fixed upstream:
@@ -23,12 +31,14 @@ async function getMetadataColumnNames(greptimeDb: GreptimeDb) {
   //      WHERE table_name = 'opentelemetry_traces' AND column_name LIKE $1`,
   //     [`${METADATA_PREFIX}%`],
   //   )
-  return (await greptimeDb.unsafe(
+  const result = (await greptimeDb.unsafe(
     `SELECT column_name
      FROM information_schema.columns
      WHERE table_name = 'opentelemetry_traces'
        AND column_name LIKE '${METADATA_PREFIX}%'`,
   )) as Array<{ column_name: unknown }>;
+  metadataColumnsCache.set("metadata_columns", result);
+  return result;
 }
 
 export async function listTraces(

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -31,7 +31,7 @@
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",
     "elysia": "catalog:",
-    "lru-cache": "^11.2.5",
+    "lru-cache": "catalog:",
     "voyage-ai-provider": "^3.0.0"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@hebo/shared-api": "workspace:*",
         "@prisma/client": "catalog:",
         "elysia": "catalog:",
+        "lru-cache": "catalog:",
       },
       "devDependencies": {
         "@hebo/typescript-config": "workspace:*",
@@ -132,7 +133,7 @@
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
         "elysia": "catalog:",
-        "lru-cache": "^11.2.5",
+        "lru-cache": "catalog:",
         "voyage-ai-provider": "^3.0.0",
       },
       "devDependencies": {
@@ -277,6 +278,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "elysia": "^1.4.27",
+    "lru-cache": "^11.2.5",
     "lucide-react": "^0.576.0",
     "prisma": "^7.4.2",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
+    "lru-cache": "^11.2.5",
     "zod": "^4.3.5"
   }
 }


### PR DESCRIPTION
Cache `getMetadataColumnNames` using a single-key `lru-cache` with a 2-second TTL to match the ingestion batch delay. Promotes `lru-cache` to a workspace catalog dependency.

Closes #259

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented caching for metadata column retrieval to improve performance with automatic cache refresh every 2 seconds.

* **Chores**
  * Standardized lru-cache dependency management across packages using monorepo catalog configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->