### PR TITLE
unpin @elysiajs/eden, upgrade elysia + bun

### DIFF
--- a/apps/api/src/modules/traces/index.ts
+++ b/apps/api/src/modules/traces/index.ts
@@ -38,13 +38,13 @@ export const spansModule = new Elysia({
         200,
         await listTraces(
           greptimeDb,
-          organizationId,
+          organizationId!,
           params.agentSlug,
           params.branchSlug,
           query.from ?? DEFAULT_FROM(),
           query.to ?? DEFAULT_TO(),
-          query.page,
-          query.pageSize,
+          query.page!,
+          query.pageSize!,
           metadata,
         ),
       );
@@ -59,7 +59,7 @@ export const spansModule = new Elysia({
     async ({ greptimeDb, organizationId, params }) => {
       const spans = await getSpans(
         greptimeDb,
-        organizationId,
+        organizationId!,
         params.agentSlug,
         params.branchSlug,
         params.traceId,

--- a/apps/api/src/modules/traces/index.ts
+++ b/apps/api/src/modules/traces/index.ts
@@ -43,6 +43,8 @@ export const spansModule = new Elysia({
           params.branchSlug,
           query.from ?? DEFAULT_FROM(),
           query.to ?? DEFAULT_TO(),
+          // FUTURE: remove '!' on page & pageSize
+          // https://github.com/elysiajs/elysia/issues/817
           query.page!,
           query.pageSize!,
           metadata,

--- a/apps/api/src/modules/traces/types.ts
+++ b/apps/api/src/modules/traces/types.ts
@@ -8,8 +8,8 @@ const TraceTimeRangeQuery = {
 export const TraceListQuery = t.Object({
   metadata: t.Optional(t.String()),
   ...TraceTimeRangeQuery,
-  page: t.Number({ default: 1 }),
-  pageSize: t.Number({ default: 20 }),
+  page: t.Optional(t.Number({ default: 1 })),
+  pageSize: t.Optional(t.Number({ default: 20 })),
 });
 
 const SpanStatus = t.Union([t.Literal("ok"), t.Literal("error"), t.Literal("unknown")]);

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/route.tsx
@@ -34,9 +34,7 @@ export async function clientLoader({
     .traces.get({
       query: {
         page: page,
-        // @ts-expect-error this works in Eden
         from: effectiveFrom,
-        // @ts-expect-error this works in Eden
         to: effectiveTo,
         metadata: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : undefined,
       },

--- a/bun.lock
+++ b/bun.lock
@@ -259,8 +259,8 @@
     "@conform-to/react": "^1.15.1",
     "@conform-to/zod": "^1.15.1",
     "@elysiajs/cors": "^1.4.1",
-    "@elysiajs/eden": "1.4.5",
-    "@elysiajs/openapi": "^1.4.13",
+    "@elysiajs/eden": "^1.4.8",
+    "@elysiajs/openapi": "^1.4.14",
     "@elysiajs/opentelemetry": "^1.4.10",
     "@opentelemetry/api": "^1.9.0",
     "@prisma/adapter-pg": "^7.4.2",
@@ -277,7 +277,7 @@
     "better-auth": "^1.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "elysia": "^1.4.27",
+    "elysia": "^1.4.28",
     "lru-cache": "^11.2.5",
     "lucide-react": "^0.576.0",
     "prisma": "^7.4.2",
@@ -490,7 +490,7 @@
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
-    "@elysiajs/eden": ["@elysiajs/eden@1.4.5", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-hIOeH+S5NU/84A7+t8yB1JjxqjmzRkBF9fnLn6y+AH8EcF39KumOAnciMhIOkhhThVZvXZ3d+GsizRc+Fxoi8g=="],
+    "@elysiajs/eden": ["@elysiajs/eden@1.4.8", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-a7oct2kFa49tH+GawZtSUCZR2rQgucNYgGLz8alXUqb4IrU3PASA0T4zXJw4MhdV1Xb6vyiR7p7kkqJcVjgbkA=="],
 
     "@elysiajs/openapi": ["@elysiajs/openapi@1.4.14", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw=="],
 
@@ -1516,7 +1516,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.307", "", {}, "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg=="],
 
-    "elysia": ["elysia@1.4.27", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-2UlmNEjPJVA/WZVPYKy+KdsrfFwwNlqSBW1lHz6i2AHc75k7gV4Rhm01kFeotH7PDiHIX2G8X3KnRPc33SGVIg=="],
+    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "engines": {
     "bun": "^1.3.10"
   },
-  "packageManager": "bun@1.3.10",
+  "packageManager": "bun@1.3.11",
   "catalog": {
     "@opentelemetry/api": "^1.9.0",
     "ai": "^6.0.105",
@@ -48,8 +48,8 @@
     "@conform-to/react": "^1.15.1",
     "@conform-to/zod": "^1.15.1",
     "@elysiajs/cors": "^1.4.1",
-    "@elysiajs/eden": "1.4.5",
-    "@elysiajs/openapi": "^1.4.13",
+    "@elysiajs/eden": "^1.4.8",
+    "@elysiajs/openapi": "^1.4.14",
     "@elysiajs/opentelemetry": "^1.4.10",
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
@@ -61,7 +61,7 @@
     "better-auth": "^1.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "elysia": "^1.4.27",
+    "elysia": "^1.4.28",
     "lucide-react": "^0.576.0",
     "prisma": "^7.4.2",
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
     "@prisma/instrumentation": "^7.4.2",
-    "@types/bun": "^1.3.11",
+    "@types/bun": "^1.3.10",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@better-auth/prisma-adapter": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "bun": "^1.3.10"
+    "bun": "^1.3.11"
   },
   "packageManager": "bun@1.3.11",
   "catalog": {
@@ -54,7 +54,7 @@
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
     "@prisma/instrumentation": "^7.4.2",
-    "@types/bun": "^1.3.10",
+    "@types/bun": "^1.3.11",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@better-auth/prisma-adapter": "^1.5.3",


### PR DESCRIPTION
- `@elysiajs/eden`: `1.4.5` → `^1.4.8`
- `elysia`: `^1.4.27` → `^1.4.28`
- `@elysiajs/openapi`: `^1.4.13` → `^1.4.14`
- Bun: `1.3.10` → `1.3.11`
- Make `page`/`pageSize` optional with defaults in schema only (no duplicate `??` fallbacks)
- Remove 2 `@ts-expect-error` suppressions (fixed `t.Date()` inference)

Closes #278

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination parameters for trace queries now have sensible defaults, simplifying list navigation.

* **Improvements**
  * Increased type safety around trace filtering to reduce runtime issues and surface problems earlier.

* **Chores**
  * Updated package dependencies for compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->