### PR TITLE
Fix locale-dependent token count formatting

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
@@ -28,7 +28,7 @@ export function truncateText(text: string, maxLength: number): string {
 
 export function formatTokenCount(count: number | null): string {
   if (count === null || count === undefined) return "-";
-  return count.toLocaleString();
+  return count.toLocaleString("en-US");
 }
 
 export function toDateTimeLocalValue(value: string): string {


### PR DESCRIPTION
## Summary

- Pin `formatTokenCount` to `en-US` locale so token counts display consistently (e.g. `34,048`) instead of using the browser default which renders `34.048` for European locales.

Closes #292

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token count formatting to display consistently using a standard locale instead of system defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->