### PR TITLE
fix: use locale-aware decimal separator in trace duration formatting

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
@@ -1,8 +1,18 @@
 import { format } from "date-fns";
 import prettyMs from "pretty-ms";
 
+function getDecimalSeparator(): string {
+  return (
+    new Intl.NumberFormat(undefined)
+      .formatToParts(1.1)
+      .find((p) => p.type === "decimal")?.value ?? "."
+  );
+}
+
 export function formatDuration(durationMs: number): string {
-  return prettyMs(durationMs);
+  const result = prettyMs(durationMs);
+  const sep = getDecimalSeparator();
+  return sep === "." ? result : result.replace(".", sep);
 }
 
 export function formatTimestampShort(ts: string): string {


### PR DESCRIPTION
Use `Intl.NumberFormat` to detect the browser's decimal separator and replace the hardcoded `.` from `pretty-ms` output, so duration and token count formatting use consistent locale conventions.

Closes #292

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duration display now respects locale-specific decimal separator settings, ensuring correct formatting for users across different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->