### PR TITLE
fix: metadata badge interactions in trace list

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
@@ -174,7 +174,11 @@ export function TraceList({
                       </p>
 
                       {Object.keys(trace.metadata).length > 0 && (
-                        <TagStrip metadata={trace.metadata} activeMetadata={metadata} allKeys={metadataKeys} />
+                        <TagStrip
+                          metadata={trace.metadata}
+                          activeMetadata={metadata}
+                          allKeys={metadataKeys}
+                        />
                       )}
                     </Link>
                   );
@@ -230,18 +234,21 @@ function TagStrip({
   activeMetadata: Record<string, string>;
   allKeys: string[];
 }) {
+  const [open, setOpen] = useState(false);
+
   const { updateParams } = useTraceSearchParams();
+
   const entries = Object.entries(metadata).sort(([a], [b]) => a.localeCompare(b));
   const visible = entries.slice(0, VISIBLE_TAG_COUNT);
   const overflowCount = entries.length - visible.length;
-
   function toggleMetadataFilter(key: string, value: string, event: React.MouseEvent) {
-    event.stopPropagation();
+    event.preventDefault();
     updateParams((sp) => sp.toggleValue("metadata", key, value));
+    setOpen(false);
   }
 
   return (
-    <HoverCard>
+    <HoverCard open={open} onOpenChange={setOpen}>
       <HoverCardTrigger
         delay={250}
         closeDelay={100}
@@ -327,6 +334,9 @@ function TagBadge({
       variant="secondary"
       className="group/tag shrink-0 gap-1 pr-1"
       style={style}
+      onClick={(e) => {
+        e.preventDefault();
+      }}
     >
       {badgeKey}: {value}
       <button

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/list.tsx
@@ -273,7 +273,13 @@ function TagStrip({
         }
       />
       {entries.length >= VISIBLE_TAG_COUNT && (
-        <HoverCardContent align="start" className="w-auto">
+        <HoverCardContent
+          align="start"
+          className="w-auto"
+          onClick={(e) => {
+            e.preventDefault();
+          }}
+        >
           <div className="flex flex-col gap-1.5">
             {entries.map(([key, value]) => (
               <TagBadge
@@ -330,14 +336,7 @@ function TagBadge({
   style?: React.CSSProperties;
 }) {
   return (
-    <Badge
-      variant="secondary"
-      className="group/tag shrink-0 gap-1 pr-1"
-      style={style}
-      onClick={(e) => {
-        e.preventDefault();
-      }}
-    >
+    <Badge variant="secondary" className="group/tag shrink-0 gap-1 pr-1" style={style}>
       {badgeKey}: {value}
       <button
         type="button"


### PR DESCRIPTION
Clicking filter buttons or badge text inside trace list items was incorrectly triggering navigation to the trace detail view. The root cause: badge clicks bubbled up to the parent <Link>, and without preventDefault(), the browser followed the <a href directly (full page reload).

**Changes:**
- Call preventDefault() on filter toggle events so React Router skips navigation
- Call preventDefault() on badge text clicks (via Badge onClick) for the same reason
- Make HoverCard controlled (open/onOpenChange) and close it when a filter is applied from the popup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover card visibility and closing behavior when interacting with tags.
  * Fixed event handling for metadata filter toggles so hover cards close correctly after updates.
  * Prevented unintended click propagation on tag badges to improve interaction stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->