### PR TITLE
fix: add invited members to agent's team using stored team_id

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -44,7 +44,7 @@ model agents {
   deleted_at      DateTime?
   /// @prismabox.hide
   organization_id String
-  /// @prismabox.hide
+  /// @prismabox.input.hide
   team_id         String
 }
 

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -188,16 +188,9 @@ export const authService: AuthService = {
       }
     }
 
-    const invitations = ((data.invitations ?? []) as unknown as (OrgInvitation & Record<string, unknown>)[])
-      .filter((i) => i.status === "pending")
-      .map(({ id, email, role, expiresAt, status, teamId }) => ({
-        id,
-        email,
-        role,
-        expiresAt,
-        status,
-        teamId: typeof teamId === "string" ? teamId : undefined,
-      }));
+    const invitations = ((data.invitations ?? []) as unknown as OrgInvitation[]).filter(
+      (i) => i.status === "pending",
+    );
 
     return { members, invitations };
   },

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -203,10 +203,11 @@ export const authService: AuthService = {
     globalThis.location.replace("/");
   },
 
-  async inviteMember(email, role) {
+  async inviteMember(email, role, teamId) {
     const { error } = await authClient.organization.inviteMember({
       email,
       role: role as "member" | "admin" | "owner",
+      ...(teamId && { teamId }),
     });
     if (error) throw new Error(error.message);
   },

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -188,9 +188,16 @@ export const authService: AuthService = {
       }
     }
 
-    const invitations = ((data.invitations ?? []) as unknown as OrgInvitation[]).filter(
-      (i) => i.status === "pending",
-    );
+    const invitations = ((data.invitations ?? []) as unknown as (OrgInvitation & Record<string, unknown>)[])
+      .filter((i) => i.status === "pending")
+      .map(({ id, email, role, expiresAt, status, teamId }) => ({
+        id,
+        email,
+        role,
+        expiresAt,
+        status,
+        teamId: typeof teamId === "string" ? teamId : undefined,
+      }));
 
     return { members, invitations };
   },
@@ -207,6 +214,7 @@ export const authService: AuthService = {
     const { error } = await authClient.organization.inviteMember({
       email,
       role: role as "member" | "admin" | "owner",
+      resend: true,
       ...(teamId && { teamId }),
     });
     if (error) throw new Error(error.message);

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -157,7 +157,7 @@ export const authService = {
     globalThis.location.replace("/");
   },
 
-  async inviteMember(email, role) {
+  async inviteMember(email, role, _teamId) {
     const organizationId = shellStore.user?.organizationId;
     if (!organizationId) throw new Error("No active organization");
     void invitations.create({

--- a/apps/console/app/lib/auth/types.ts
+++ b/apps/console/app/lib/auth/types.ts
@@ -47,6 +47,7 @@ export type OrgInvitation = {
   role: string;
   expiresAt: string;
   status: string;
+  teamId?: string;
 };
 
 export type ApiKey = {

--- a/apps/console/app/lib/auth/types.ts
+++ b/apps/console/app/lib/auth/types.ts
@@ -10,7 +10,7 @@ export interface AuthService {
   // Organization
   getOrganization(): Promise<{ members: OrgMember[]; invitations: OrgInvitation[] }>;
   setActiveOrganization(orgId: string): Promise<void>;
-  inviteMember(email: string, role: string): Promise<void>;
+  inviteMember(email: string, role: string, teamId?: string): Promise<void>;
   removeMember(memberIdOrEmail: string): Promise<void>;
   cancelInvitation(invitationId: string): Promise<void>;
   acceptInvitation(invitationId: string): Promise<void>;

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/invite-schema.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/invite-schema.ts
@@ -3,4 +3,5 @@ import { z } from "zod";
 export const inviteSchema = z.object({
   email: z.email("Enter a valid email address"),
   role: z.enum(["member", "admin"]),
+  teamId: z.string().optional(),
 });

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/route.tsx
@@ -12,12 +12,11 @@ export async function clientAction({ request }: { request: Request }) {
   if (intent === "invite") {
     const submission = parseWithZod(formData, { schema: inviteSchema });
     if (submission.status !== "success") return { intent, submission: submission.reply() };
-    const teamId = formData.get("teamId");
     try {
       await authService.inviteMember(
         submission.value.email,
         submission.value.role,
-        typeof teamId === "string" ? teamId : undefined,
+        submission.value.teamId,
       );
     } catch (error) {
       return { intent, submission: submission.reply({ formErrors: [parseError(error).message] }) };

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings.members/route.tsx
@@ -12,8 +12,13 @@ export async function clientAction({ request }: { request: Request }) {
   if (intent === "invite") {
     const submission = parseWithZod(formData, { schema: inviteSchema });
     if (submission.status !== "success") return { intent, submission: submission.reply() };
+    const teamId = formData.get("teamId");
     try {
-      await authService.inviteMember(submission.value.email, submission.value.role);
+      await authService.inviteMember(
+        submission.value.email,
+        submission.value.role,
+        typeof teamId === "string" ? teamId : undefined,
+      );
     } catch (error) {
       return { intent, submission: submission.reply({ formErrors: [parseError(error).message] }) };
     }

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -45,6 +45,7 @@ type MembersSettingsProps = {
   invitations: OrgInvitation[];
   isOwner: boolean;
   canManage: boolean;
+  teamId?: string | null;
 };
 
 export function MembersSettings({
@@ -52,6 +53,7 @@ export function MembersSettings({
   invitations,
   isOwner,
   canManage,
+  teamId,
 }: MembersSettingsProps) {
   const fetcher = useFetcher<{ intent: string; submission: any }>();
   const [role, setRole] = useState("member");
@@ -159,6 +161,7 @@ export function MembersSettings({
             className="flex items-end gap-3"
           >
             <input type="hidden" name="intent" value="invite" />
+            {teamId && <input type="hidden" name="teamId" value={teamId} />}
             <Field name={fields.email.name} className="flex-1">
               <FieldLabel>Email</FieldLabel>
               <FieldControl>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -49,12 +49,11 @@ type MembersSettingsProps = {
 };
 export function MembersSettings({
   members,
-  invitations: allInvitations,
+  invitations,
   isOwner,
   canManage,
   agent,
 }: MembersSettingsProps) {
-  const invitations = allInvitations.filter((i) => i.teamId === agent.team_id);
   const fetcher = useFetcher<{ intent: string; submission: any }>();
   const [role, setRole] = useState("member");
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -49,11 +49,12 @@ type MembersSettingsProps = {
 };
 export function MembersSettings({
   members,
-  invitations,
+  invitations: allInvitations,
   isOwner,
   canManage,
   agent,
 }: MembersSettingsProps) {
+  const invitations = allInvitations.filter((i) => i.teamId === agent.team_id);
   const fetcher = useFetcher<{ intent: string; submission: any }>();
   const [role, setRole] = useState("member");
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -45,15 +45,14 @@ type MembersSettingsProps = {
   invitations: OrgInvitation[];
   isOwner: boolean;
   canManage: boolean;
-  teamId?: string | null;
+  agent: { team_id: string };
 };
-
 export function MembersSettings({
   members,
   invitations,
   isOwner,
   canManage,
-  teamId,
+  agent,
 }: MembersSettingsProps) {
   const fetcher = useFetcher<{ intent: string; submission: any }>();
   const [role, setRole] = useState("member");
@@ -161,7 +160,7 @@ export function MembersSettings({
             className="flex items-end gap-3"
           >
             <input type="hidden" name="intent" value="invite" />
-            {teamId && <input type="hidden" name="teamId" value={teamId} />}
+            <input type="hidden" name="teamId" value={agent.team_id} />
             <Field name={fields.email.name} className="flex-1">
               <FieldLabel>Email</FieldLabel>
               <FieldControl>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
@@ -28,6 +28,7 @@ export default function Settings({ loaderData }: Route.ComponentProps) {
         invitations={loaderData.invitations}
         isOwner={loaderData.isOwner}
         canManage={loaderData.canManage}
+        teamId={agent.team_id}
       />
       <DangerSettings agent={agent} />
     </div>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
@@ -25,7 +25,7 @@ export default function Settings({ loaderData }: Route.ComponentProps) {
       <GeneralSettings agent={agent} />
       <MembersSettings
         members={loaderData.members}
-        invitations={loaderData.invitations}
+        invitations={loaderData.invitations.filter((i) => i.teamId === agent.team_id)}
         isOwner={loaderData.isOwner}
         canManage={loaderData.canManage}
         agent={agent}

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/route.tsx
@@ -28,7 +28,7 @@ export default function Settings({ loaderData }: Route.ComponentProps) {
         invitations={loaderData.invitations}
         isOwner={loaderData.isOwner}
         canManage={loaderData.canManage}
-        teamId={agent.team_id}
+        agent={agent}
       />
       <DangerSettings agent={agent} />
     </div>


### PR DESCRIPTION
Pass the agent's `team_id` through the invite form as a hidden field instead of re-querying the agent on submit. The `team_id` is already available from the parent route's loader data.

Closes #301

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team-scoped member invitations: invites now include team context, are submitted with team info, and pending invites are shown per team.
  * Invite form and members list automatically associate and filter invitations by the current agent/team.

* **Bug Fixes**
  * Improved handling of pending invitations to display consistent fields and support resend behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->