### PR TITLE
feat: add password auth fallback with VITE_MAGICLINK_AUTH

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -21,7 +21,7 @@ export const prisma = new PrismaClient({
 export const auth = betterAuth({
   accountLinking: {
     enabled: true,
-    trustedProviders: ["google", "github", "microsoft", "credential"],
+    trustedProviders: ["google", "github", "microsoft", "email-password"],
   },
   emailAndPassword: {
     enabled: !hasSmtpConfig(),

--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -10,7 +10,7 @@ import { getSecret } from "@hebo/shared-api/utils/secrets";
 
 import { PrismaClient } from "~auth/generated/prisma/client";
 
-import { sendOrganizationInvitationEmail, sendVerificationOtpEmail } from "./lib/email";
+import { hasSmtpConfig, sendOrganizationInvitationEmail, sendVerificationOtpEmail } from "./lib/email";
 import { createOrganizationHook, syncActiveOrganizationHook } from "./lib/organization";
 import { verifyApiKeyPlugin, type AuthWithApiKeyPlugin } from "./lib/verify-api-key-plugin";
 
@@ -21,7 +21,10 @@ export const prisma = new PrismaClient({
 export const auth = betterAuth({
   accountLinking: {
     enabled: true,
-    trustedProviders: ["google", "github", "microsoft"],
+    trustedProviders: ["google", "github", "microsoft", "credential"],
+  },
+  emailAndPassword: {
+    enabled: !hasSmtpConfig(),
   },
   advanced: {
     ...betterAuthCookieOptions.advanced,

--- a/apps/auth/src/lib/email.ts
+++ b/apps/auth/src/lib/email.ts
@@ -95,9 +95,10 @@ export async function sendOrganizationInvitationEmail({
   inviterEmail: string;
   consoleUrl?: string;
 }) {
-  const acceptUrl = new URL("/accept-invitation", consoleUrl);
   if (!hasSmtpConfig()) return;
   if (!consoleUrl) return console.warn("Missing origin header, cannot send invitation email");
+
+  const acceptUrl = new URL("/accept-invitation", consoleUrl);
 
   acceptUrl.searchParams.set("id", invitationId);
   const inviter = inviterName || inviterEmail;

--- a/apps/auth/src/lib/email.ts
+++ b/apps/auth/src/lib/email.ts
@@ -1,7 +1,6 @@
 import { createMessage } from "@upyo/core";
 import { SmtpTransport } from "@upyo/smtp";
 
-import { isProduction } from "@hebo/shared-api/env";
 import { getSecret } from "@hebo/shared-api/utils/secrets";
 
 const smtpHost = await getSecret("SmtpHost");
@@ -18,7 +17,7 @@ const transport = new SmtpTransport({
   auth: { user: smtpUser, pass: smtpPass },
 });
 
-const hasSmtpConfig = () => smtpHost && smtpPort && smtpUser && smtpPass && smtpFrom;
+export const hasSmtpConfig = () => !!(smtpHost && smtpPort && smtpUser && smtpPass && smtpFrom);
 
 const emailTemplate = (title: string, subtitle: string, body: string) => `
 <table width="100%" cellpadding="0" cellspacing="0" style="background:linear-gradient(180deg,#fefce8 0%,#f8fafc 45%,#eef2ff 100%);padding:32px 0;color:#0f172a;font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
@@ -53,10 +52,7 @@ export async function sendVerificationOtpEmail({
   otp: string;
   consoleUrl?: string;
 }) {
-  if (!isProduction) {
-    console.info(">>> OTP:", otp);
-    if (!hasSmtpConfig()) return;
-  }
+  if (!hasSmtpConfig()) return;
   if (!consoleUrl) return console.warn("Missing origin header, cannot send verification email");
 
   const magicLinkUrl = new URL("/signin/magic-link", consoleUrl);
@@ -100,10 +96,7 @@ export async function sendOrganizationInvitationEmail({
   consoleUrl?: string;
 }) {
   const acceptUrl = new URL("/accept-invitation", consoleUrl);
-  if (!isProduction) {
-    console.info(`>>> Organization Invitation: ${acceptUrl.toString()}?id=${invitationId}`);
-    if (!hasSmtpConfig()) return;
-  }
+  if (!hasSmtpConfig()) return;
   if (!consoleUrl) return console.warn("Missing origin header, cannot send invitation email");
 
   acceptUrl.searchParams.set("id", invitationId);

--- a/apps/console/app/lib/auth/better-auth.ts
+++ b/apps/console/app/lib/auth/better-auth.ts
@@ -168,6 +168,27 @@ export const authService: AuthService = {
     globalThis.location.replace(appRedirectPath);
   },
 
+  async signInWithPassword(email: string, password: string) {
+    const { error } = await authClient.signIn.email({
+      email,
+      password,
+      callbackURL: appRedirectPath,
+    });
+    if (error) throw new Error(error.message ?? "Invalid credentials");
+    globalThis.location.replace(appRedirectPath);
+  },
+
+  async signUpWithPassword(name: string, email: string, password: string) {
+    const { error } = await authClient.signUp.email({
+      name,
+      email,
+      password,
+      callbackURL: appRedirectPath,
+    });
+    if (error) throw new Error(error.message ?? "Sign-up failed");
+    globalThis.location.replace(appRedirectPath);
+  },
+
   async signOut() {
     await authClient.signOut();
     shellStore.user = undefined;

--- a/apps/console/app/lib/auth/dummy-auth.ts
+++ b/apps/console/app/lib/auth/dummy-auth.ts
@@ -114,6 +114,14 @@ export const authService = {
     throw new Error("Magic Link not implemented");
   },
 
+  async signInWithPassword() {
+    globalThis.location.href = "/";
+  },
+
+  async signUpWithPassword() {
+    globalThis.location.href = "/";
+  },
+
   async signOut() {
     shellStore.user = undefined;
     shellStore.organizations = [];

--- a/apps/console/app/lib/auth/types.ts
+++ b/apps/console/app/lib/auth/types.ts
@@ -6,6 +6,8 @@ export interface AuthService {
   signInWithOAuth(provider: string): Promise<void>;
   sendMagicLinkEmail(email: string): Promise<string>;
   signInWithMagicLink(code: string, email: string): Promise<void>;
+  signInWithPassword(email: string, password: string): Promise<void>;
+  signUpWithPassword(name: string, email: string, password: string): Promise<void>;
   signOut(): Promise<void>;
   // Organization
   getOrganization(): Promise<{ members: OrgMember[]; invitations: OrgInvitation[] }>;

--- a/apps/console/app/lib/env.ts
+++ b/apps/console/app/lib/env.ts
@@ -17,3 +17,5 @@ export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:3000";
 export const gatewayUrl = useMocks
   ? "http://localhost:5173/gateway"
   : import.meta.env.VITE_GATEWAY_URL || "http://localhost:3002";
+
+export const magicLinkAuth = import.meta.env.VITE_MAGICLINK_AUTH === "true";

--- a/apps/console/app/routes/_auth.accept-invitation/route.tsx
+++ b/apps/console/app/routes/_auth.accept-invitation/route.tsx
@@ -32,7 +32,7 @@ export default function AcceptInvitation({ loaderData: data }: Route.ComponentPr
   }, [data.status]);
 
   return (
-    <div className="mx-auto flex min-h-dvh w-xs flex-col items-center justify-center gap-6">
+    <div className="flex w-xs flex-col items-center gap-6">
       <Logo />
 
       {data.status === "success" && (

--- a/apps/console/app/routes/_auth.signin/magiclink.tsx
+++ b/apps/console/app/routes/_auth.signin/magiclink.tsx
@@ -82,7 +82,11 @@ export function MagicLinkSignIn() {
           Verify
         </Button>
       </div>
-      {error && <div className="text-sm text-destructive">{error}</div>}
+      {error && (
+        <div role="alert" className="text-sm text-destructive">
+          {error}
+        </div>
+      )}
       <Button
         type="button"
         variant="link"

--- a/apps/console/app/routes/_auth.signin/password.tsx
+++ b/apps/console/app/routes/_auth.signin/password.tsx
@@ -42,7 +42,6 @@ export function PasswordSignIn() {
       onSubmit={async (e) => {
         e.preventDefault();
         setLoading(true);
-        setError(undefined);
         try {
           await authService.signInWithPassword(email, password);
         } catch (err) {
@@ -70,18 +69,22 @@ export function PasswordSignIn() {
         </Button>
       </div>
 
-      {error && (
-        <div role="alert" className="text-sm text-destructive">
+      {error ? (
+        <div role="alert" className="py-2 text-center text-sm text-destructive">
           {error}
+          {"! "}
+          <Link to="/signup" viewTransition className="font-medium text-foreground underline">
+            Sign up instead?
+          </Link>
         </div>
+      ) : (
+        <p className="py-2 text-center text-sm">
+          Don't have an account?{" "}
+          <Link to="/signup" viewTransition className="font-medium underline">
+            Sign up
+          </Link>
+        </p>
       )}
-
-      <p className="py-2 text-center text-sm">
-        Don't have an account?{" "}
-        <Link to="/signup" viewTransition className="font-medium underline">
-          Sign up
-        </Link>
-      </p>
     </form>
   );
 }

--- a/apps/console/app/routes/_auth.signin/password.tsx
+++ b/apps/console/app/routes/_auth.signin/password.tsx
@@ -1,4 +1,3 @@
-import { Loader2Icon } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router";
 
@@ -10,11 +9,34 @@ import { authService } from "~console/lib/auth";
 
 export function PasswordSignIn() {
   const [email, setEmail] = useState("");
+  const [emailSubmitted, setEmailSubmitted] = useState(false);
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
 
-  return (
+  return !emailSubmitted ? (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        setError(undefined);
+        setEmailSubmitted(true);
+      }}
+    >
+      <Label htmlFor="email">Email</Label>
+      <Input
+        id="email"
+        type="email"
+        autoComplete="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={loading}
+        required
+      />
+
+      <Button type="submit">Continue</Button>
+    </form>
+  ) : (
     <form
       className="flex flex-col gap-2"
       onSubmit={async (e) => {
@@ -30,37 +52,33 @@ export function PasswordSignIn() {
         }
       }}
     >
-      <Label htmlFor="email">Email</Label>
-      <Input
-        id="email"
-        type="email"
-        autoComplete="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        disabled={loading}
-        required
-      />
-
       <Label htmlFor="password">Password</Label>
-      <Input
-        id="password"
-        type="password"
-        autoComplete="current-password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        disabled={loading}
-        required
-      />
+      <div className="flex gap-2">
+        <Input
+          id="password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={loading}
+          required
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+        />
+        <Button type="submit" isLoading={loading}>
+          Sign In
+        </Button>
+      </div>
 
-      <Button type="submit" disabled={loading}>
-        {loading ? <Loader2Icon className="animate-spin" /> : "Sign In"}
-      </Button>
+      {error && (
+        <div role="alert" className="text-sm text-destructive">
+          {error}
+        </div>
+      )}
 
-      {error && <div role="alert" className="text-sm text-destructive">{error}</div>}
-
-      <p className="text-center text-sm">
+      <p className="py-2 text-center text-sm">
         Don't have an account?{" "}
-        <Link to="/signup" className="font-medium underline">
+        <Link to="/signup" viewTransition className="font-medium underline">
           Sign up
         </Link>
       </p>

--- a/apps/console/app/routes/_auth.signin/password.tsx
+++ b/apps/console/app/routes/_auth.signin/password.tsx
@@ -1,0 +1,69 @@
+import { Loader2Icon } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router";
+
+import { Button } from "@hebo/shared-ui/components/Button";
+import { Input } from "@hebo/shared-ui/components/Input";
+import { Label } from "@hebo/shared-ui/components/Label";
+
+import { authService } from "~console/lib/auth";
+
+export function PasswordSignIn() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(undefined);
+        try {
+          await authService.signInWithPassword(email, password);
+        } catch (err) {
+          if (err instanceof Error) setError(err.message);
+        } finally {
+          setLoading(false);
+        }
+      }}
+    >
+      <Label htmlFor="email">Email</Label>
+      <Input
+        id="email"
+        type="email"
+        autoComplete="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={loading}
+        required
+      />
+
+      <Label htmlFor="password">Password</Label>
+      <Input
+        id="password"
+        type="password"
+        autoComplete="current-password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        disabled={loading}
+        required
+      />
+
+      <Button type="submit" disabled={loading}>
+        {loading ? <Loader2Icon className="animate-spin" /> : "Sign In"}
+      </Button>
+
+      {error && <div className="text-sm text-destructive">{error}</div>}
+
+      <p className="text-center text-sm">
+        Don't have an account?{" "}
+        <Link to="/signup" className="font-medium underline">
+          Sign up
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/apps/console/app/routes/_auth.signin/password.tsx
+++ b/apps/console/app/routes/_auth.signin/password.tsx
@@ -56,7 +56,7 @@ export function PasswordSignIn() {
         {loading ? <Loader2Icon className="animate-spin" /> : "Sign In"}
       </Button>
 
-      {error && <div className="text-sm text-destructive">{error}</div>}
+      {error && <div role="alert" className="text-sm text-destructive">{error}</div>}
 
       <p className="text-center text-sm">
         Don't have an account?{" "}

--- a/apps/console/app/routes/_auth.signin/route.tsx
+++ b/apps/console/app/routes/_auth.signin/route.tsx
@@ -1,7 +1,4 @@
-import { Ban, BookOpen, CreditCard } from "lucide-react";
-
-import { Badge } from "@hebo/shared-ui/components/Badge";
-import { Button } from "@hebo/shared-ui/components/Button";
+import { Ban, CreditCard } from "lucide-react";
 
 import { Logo } from "~console/components/ui/Logo";
 import { magicLinkAuth } from "~console/lib/env";
@@ -12,67 +9,27 @@ import { PasswordSignIn } from "./password";
 
 export default function SignIn() {
   return (
-    <div className="relative min-h-dvh">
-      {/* Marketing Message */}
-      <aside className="fixed min-h-dvh w-lg -translate-x-full bg-accent bg-[url(/login-bg.png)] bg-bottom-left bg-no-repeat transition-transform duration-300 ease-in-out lg:translate-x-0">
-        <Button
-          variant="secondary"
-          className="absolute top-5 left-6"
-          nativeButton={false}
-          render={
-            <a href="https://hebo.ai/docs" target="_blank" rel="noopener">
-              <BookOpen />
-              <span>Docs</span>
-            </a>
-          }
-        />
+    <div className="flex w-xs flex-col items-center gap-4">
+      <Logo />
+      <p className="text-center text-base">The fastest way to build & scale agents</p>
 
-        <div className="space-y-5 px-19 py-30 text-xl">
-          <div className="flex items-center gap-2 text-3xl font-semibold">
-            Hebo is{}
-            <Badge className="h-10 bg-lime-400 text-3xl font-semibold text-foreground">FREE</Badge>
-          </div>
-          <div className="space-y-2">
-            <div className="font-semibold">Deploy agents to production:</div>
-            <ul className="space-y-2">
-              <li>✔️ Choose from a set of free open-source models</li>
-              <li>✔️ Use commercial models within fair-usage policy</li>
-              <li>✔️ Bring your own key to use 3rd party credits</li>
-            </ul>
-          </div>
-          <span className="font-semibold">Get in touch</span> with us on{" "}
-          <a href="https://discord.com/invite/cCJtXZRU5p" target="_blank" rel="noopener noreferrer">
-            Discord
-          </a>{" "}
-          to learn about our special programs, including student ambassadors.
+      <div className="w-full space-y-4">
+        <OAuthSignIn />
+        <div className="flex items-center gap-4">
+          <div className="h-px flex-1 bg-gray-300" />
+          <span className="text-sm whitespace-nowrap">or</span>
+          <div className="h-px flex-1 bg-gray-300" />
         </div>
-      </aside>
+        {magicLinkAuth ? <MagicLinkSignIn /> : <PasswordSignIn />}
+      </div>
 
-      {/* Login Components */}
-      <main className="flex min-h-dvh flex-1 items-center justify-center transition-all duration-300 lg:ml-128">
-        <div className="flex w-xs flex-col items-center gap-4">
-          <Logo />
-          <p className="text-center text-base">The fastest way to build & scale agents</p>
-
-          <div className="w-full space-y-4">
-            <OAuthSignIn />
-            <div className="flex items-center gap-4">
-              <div className="h-px flex-1 bg-gray-300" />
-              <span className="text-sm whitespace-nowrap">or</span>
-              <div className="h-px flex-1 bg-gray-300" />
-            </div>
-            {magicLinkAuth ? <MagicLinkSignIn /> : <PasswordSignIn />}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="relative">
-              <Ban className="h-4 w-4" />
-              <CreditCard className="absolute top-1 left-1 h-2 w-2" />
-            </span>
-            <span className="text-sm">No credit card required</span>
-          </div>
-        </div>
-      </main>
+      <div className="flex items-center gap-2">
+        <span className="relative">
+          <Ban className="h-4 w-4" />
+          <CreditCard className="absolute top-1 left-1 h-2 w-2" />
+        </span>
+        <span className="text-sm">No credit card required</span>
+      </div>
     </div>
   );
 }

--- a/apps/console/app/routes/_auth.signin/route.tsx
+++ b/apps/console/app/routes/_auth.signin/route.tsx
@@ -4,9 +4,11 @@ import { Badge } from "@hebo/shared-ui/components/Badge";
 import { Button } from "@hebo/shared-ui/components/Button";
 
 import { Logo } from "~console/components/ui/Logo";
+import { magicLinkAuth } from "~console/lib/env";
 
 import { MagicLinkSignIn } from "./magiclink";
 import { OAuthSignIn } from "./oauth";
+import { PasswordSignIn } from "./password";
 
 export default function SignIn() {
   return (
@@ -59,7 +61,7 @@ export default function SignIn() {
               <span className="text-sm whitespace-nowrap">or</span>
               <div className="h-px flex-1 bg-gray-300" />
             </div>
-            <MagicLinkSignIn />
+            {magicLinkAuth ? <MagicLinkSignIn /> : <PasswordSignIn />}
           </div>
 
           <div className="flex items-center gap-2">

--- a/apps/console/app/routes/_auth.signin/route.tsx
+++ b/apps/console/app/routes/_auth.signin/route.tsx
@@ -24,7 +24,7 @@ export default function SignIn() {
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="relative">
+        <span className="relative" aria-hidden="true">
           <Ban className="h-4 w-4" />
           <CreditCard className="absolute top-1 left-1 h-2 w-2" />
         </span>

--- a/apps/console/app/routes/_auth.signup/route.tsx
+++ b/apps/console/app/routes/_auth.signup/route.tsx
@@ -1,0 +1,90 @@
+import { Loader2Icon } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router";
+
+import { Button } from "@hebo/shared-ui/components/Button";
+import { Input } from "@hebo/shared-ui/components/Input";
+import { Label } from "@hebo/shared-ui/components/Label";
+
+import { Logo } from "~console/components/ui/Logo";
+import { authService } from "~console/lib/auth";
+
+export default function SignUp() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center">
+      <div className="flex w-xs flex-col items-center gap-4">
+        <Logo />
+        <p className="text-center text-base">Create your account</p>
+
+        <form
+          className="flex w-full flex-col gap-2"
+          onSubmit={async (e) => {
+            e.preventDefault();
+            setLoading(true);
+            setError(undefined);
+            try {
+              await authService.signUpWithPassword(name, email, password);
+            } catch (err) {
+              if (err instanceof Error) setError(err.message);
+            } finally {
+              setLoading(false);
+            }
+          }}
+        >
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            type="text"
+            autoComplete="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={loading}
+            required
+          />
+
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={loading}
+            required
+          />
+
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={loading}
+            minLength={8}
+            required
+          />
+
+          <Button type="submit" disabled={loading}>
+            {loading ? <Loader2Icon className="animate-spin" /> : "Sign Up"}
+          </Button>
+
+          {error && <div className="text-sm text-destructive">{error}</div>}
+
+          <p className="text-center text-sm">
+            Already have an account?{" "}
+            <Link to="/signin" className="font-medium underline">
+              Sign in
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/app/routes/_auth.signup/route.tsx
+++ b/apps/console/app/routes/_auth.signup/route.tsx
@@ -17,74 +17,76 @@ export default function SignUp() {
   const [error, setError] = useState<string | undefined>();
 
   return (
-    <div className="flex min-h-dvh items-center justify-center">
-      <div className="flex w-xs flex-col items-center gap-4">
-        <Logo />
-        <p className="text-center text-base">Create your account</p>
+    <div className="flex w-xs flex-col items-center gap-4">
+      <Logo />
+      <p className="text-center text-base">Create your account</p>
 
-        <form
-          className="flex w-full flex-col gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            setLoading(true);
-            setError(undefined);
-            try {
-              await authService.signUpWithPassword(name, email, password);
-            } catch (err) {
-              if (err instanceof Error) setError(err.message);
-            } finally {
-              setLoading(false);
-            }
-          }}
-        >
-          <Label htmlFor="name">Name</Label>
-          <Input
-            id="name"
-            type="text"
-            autoComplete="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            disabled={loading}
-            required
-          />
+      <form
+        className="flex w-full flex-col gap-2"
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setLoading(true);
+          setError(undefined);
+          try {
+            await authService.signUpWithPassword(name, email, password);
+          } catch (err) {
+            if (err instanceof Error) setError(err.message);
+          } finally {
+            setLoading(false);
+          }
+        }}
+      >
+        <Label htmlFor="name">Name</Label>
+        <Input
+          id="name"
+          type="text"
+          autoComplete="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={loading}
+          required
+        />
 
-          <Label htmlFor="email">Email</Label>
-          <Input
-            id="email"
-            type="email"
-            autoComplete="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            disabled={loading}
-            required
-          />
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={loading}
+          required
+        />
 
-          <Label htmlFor="password">Password</Label>
-          <Input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            disabled={loading}
-            minLength={8}
-            required
-          />
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          type="password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={loading}
+          minLength={8}
+          required
+        />
 
-          <Button type="submit" disabled={loading}>
-            {loading ? <Loader2Icon className="animate-spin" /> : "Sign Up"}
-          </Button>
+        <Button type="submit" disabled={loading}>
+          {loading ? <Loader2Icon className="animate-spin" /> : "Sign Up"}
+        </Button>
 
-          {error && <div role="alert" className="text-sm text-destructive">{error}</div>}
+        {error && (
+          <div role="alert" className="text-sm text-destructive">
+            {error}
+          </div>
+        )}
 
-          <p className="text-center text-sm">
-            Already have an account?{" "}
-            <Link to="/signin" className="font-medium underline">
-              Sign in
-            </Link>
-          </p>
-        </form>
-      </div>
+        <p className="text-center text-sm">
+          Already have an account?{" "}
+          <Link to="/signin" viewTransition className="font-medium underline">
+            Sign in
+          </Link>
+        </p>
+      </form>
     </div>
   );
 }

--- a/apps/console/app/routes/_auth.signup/route.tsx
+++ b/apps/console/app/routes/_auth.signup/route.tsx
@@ -75,7 +75,7 @@ export default function SignUp() {
             {loading ? <Loader2Icon className="animate-spin" /> : "Sign Up"}
           </Button>
 
-          {error && <div className="text-sm text-destructive">{error}</div>}
+          {error && <div role="alert" className="text-sm text-destructive">{error}</div>}
 
           <p className="text-center text-sm">
             Already have an account?{" "}

--- a/apps/console/app/routes/_auth/route.tsx
+++ b/apps/console/app/routes/_auth/route.tsx
@@ -1,0 +1,49 @@
+import { BookOpen } from "lucide-react";
+import { Outlet } from "react-router";
+
+import { Badge } from "@hebo/shared-ui/components/Badge";
+import { Button } from "@hebo/shared-ui/components/Button";
+
+export default function AuthLayout() {
+  return (
+    <div className="relative min-h-dvh">
+      <aside className="fixed min-h-dvh w-lg -translate-x-full bg-accent bg-[url(/login-bg.png)] bg-bottom-left bg-no-repeat transition-transform duration-300 ease-in-out lg:translate-x-0">
+        <Button
+          variant="secondary"
+          className="absolute top-5 left-6"
+          nativeButton={false}
+          render={
+            <a href="https://hebo.ai/docs" target="_blank" rel="noopener">
+              <BookOpen />
+              <span>Docs</span>
+            </a>
+          }
+        />
+
+        <div className="space-y-5 px-19 py-30 text-xl">
+          <div className="flex items-center gap-2 text-3xl font-semibold">
+            Hebo is{}
+            <Badge className="h-10 bg-lime-400 text-3xl font-semibold text-foreground">FREE</Badge>
+          </div>
+          <div className="space-y-2">
+            <div className="font-semibold">Deploy agents to production:</div>
+            <ul className="space-y-2">
+              <li>✔️ Choose from a set of free open-source models</li>
+              <li>✔️ Use commercial models within fair-usage policy</li>
+              <li>✔️ Bring your own key to use 3rd party credits</li>
+            </ul>
+          </div>
+          <span className="font-semibold">Get in touch</span> with us on{" "}
+          <a href="https://discord.com/invite/cCJtXZRU5p" target="_blank" rel="noopener noreferrer">
+            Discord
+          </a>{" "}
+          to learn about our special programs, including student ambassadors.
+        </div>
+      </aside>
+
+      <main className="flex min-h-dvh flex-1 items-center justify-center transition-all duration-300 lg:ml-128">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
-import { Mail, Trash2, UserPlus } from "lucide-react";
+import { Link, Mail, Trash2, UserPlus } from "lucide-react";
 import { useState } from "react";
 import { useFetcher } from "react-router";
 
@@ -142,6 +142,7 @@ export function MembersSettings({
                       <CopyButton
                         value={`${window.location.origin}/accept-invitation?id=${encodeURIComponent(inv.id)}`}
                         tooltip="Copy invitation link"
+                        icon={<Link />}
                       />
                       <RevokeInvitationButton invitationId={inv.id} />
                     </div>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
-import { Mail, Trash2, UserPlus } from "lucide-react";
+import { Check, Link2, Mail, Trash2, UserPlus } from "lucide-react";
 import { useState } from "react";
 import { useFetcher } from "react-router";
 
@@ -137,7 +137,10 @@ export function MembersSettings({
                 <TableCell>expires {new Date(inv.expiresAt).toLocaleDateString()}</TableCell>
                 {canManage && (
                   <TableCell>
-                    <RevokeInvitationButton invitationId={inv.id} />
+                    <div className="flex items-center">
+                      <CopyInvitationLinkButton invitationId={inv.id} />
+                      <RevokeInvitationButton invitationId={inv.id} />
+                    </div>
                   </TableCell>
                 )}
               </TableRow>
@@ -221,6 +224,24 @@ function RemoveMemberButton({ email }: { email: string }) {
         </fetcher.Form>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+function CopyInvitationLinkButton({ invitationId }: { invitationId: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    const url = `${window.location.origin}/accept-invitation?id=${encodeURIComponent(invitationId)}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Button variant="ghost" size="icon" aria-label="Copy invitation link" onClick={handleCopy}>
+      {copied ? <Check className="text-green-500" /> : <Link2 />}
+    </Button>
   );
 }
 

--- a/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.settings/members.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
-import { Check, Link2, Mail, Trash2, UserPlus } from "lucide-react";
+import { Mail, Trash2, UserPlus } from "lucide-react";
 import { useState } from "react";
 import { useFetcher } from "react-router";
 
@@ -18,6 +18,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@hebo/shared-ui/components/Avatar";
 import { Badge } from "@hebo/shared-ui/components/Badge";
 import { Button } from "@hebo/shared-ui/components/Button";
+import { CopyButton } from "@hebo/shared-ui/components/CopyButton";
 import {
   FieldControl,
   Field,
@@ -138,7 +139,10 @@ export function MembersSettings({
                 {canManage && (
                   <TableCell>
                     <div className="flex items-center">
-                      <CopyInvitationLinkButton invitationId={inv.id} />
+                      <CopyButton
+                        value={`${window.location.origin}/accept-invitation?id=${encodeURIComponent(inv.id)}`}
+                        tooltip="Copy invitation link"
+                      />
                       <RevokeInvitationButton invitationId={inv.id} />
                     </div>
                   </TableCell>
@@ -224,24 +228,6 @@ function RemoveMemberButton({ email }: { email: string }) {
         </fetcher.Form>
       </AlertDialogContent>
     </AlertDialog>
-  );
-}
-
-function CopyInvitationLinkButton({ invitationId }: { invitationId: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    const url = `${window.location.origin}/accept-invitation?id=${encodeURIComponent(invitationId)}`;
-    navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  };
-
-  return (
-    <Button variant="ghost" size="icon" aria-label="Copy invitation link" onClick={handleCopy}>
-      {copied ? <Check className="text-green-500" /> : <Link2 />}
-    </Button>
   );
 }
 

--- a/infra/stacks/console.ts
+++ b/infra/stacks/console.ts
@@ -3,7 +3,7 @@
 
 import heboApi from "./api";
 import heboAuth from "./auth";
-import { isProduction, normalizedStage } from "./env";
+import { isProduction, normalizedStage, smtpHost } from "./env";
 import heboGateway from "./gateway";
 
 const heboConsole = new sst.aws.StaticSite("HeboConsole", {
@@ -17,6 +17,7 @@ const heboConsole = new sst.aws.StaticSite("HeboConsole", {
     VITE_API_URL: heboApi.url,
     VITE_AUTH_URL: heboAuth.url,
     VITE_GATEWAY_URL: heboGateway.url,
+    VITE_MAGICLINK_AUTH: smtpHost.value.apply((v) => (v !== "undefined" ? "true" : "")),
   },
 });
 

--- a/packages/shared-ui/src/components/CopyButton.tsx
+++ b/packages/shared-ui/src/components/CopyButton.tsx
@@ -9,12 +9,14 @@ export function CopyButton({
   className,
   disabled = false,
   tooltip = "Copy to Clipboard",
+  icon = <Copy />,
   ...props
 }: {
   value: string | (() => string);
   className?: string;
   disabled?: boolean;
   tooltip?: string;
+  icon?: React.ReactNode;
 } & Omit<React.ComponentProps<"button">, "value">) {
   const [hasCopied, setHasCopied] = React.useState(false);
 
@@ -57,7 +59,7 @@ export function CopyButton({
             {...props}
           >
             <span className="sr-only">Copy</span>
-            {hasCopied ? <Check className="text-green-800" /> : <Copy />}
+            {hasCopied ? <Check className="text-green-800" /> : icon}
           </button>
         }
       />


### PR DESCRIPTION
Password auth is now the default (no env var needed). Set `VITE_MAGICLINK_AUTH=true` to switch to email OTP magic link flow.

- Auth service: `emailAndPassword` enabled when SMTP is not configured
- Console: password sign-in/sign-up forms shown by default
- SST: `VITE_MAGICLINK_AUTH` derived from SmtpHost secret
- Removes console-based OTP logger dev workaround

Closes #299

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based sign-up and two-step sign-in (email → password) added; sign-in method auto-switches based on email service availability.

* **UI Improvements**
  * Simplified sign-in page and new overall auth layout with marketing panel and nested auth routes.
  * Acceptance/invitation layout spacing adjusted.

* **Usability**
  * Invitation rows include a copy-invitation-link button with visual feedback.
  * Forms show loading/disabled states during submit.

* **Accessibility**
  * Error messages in sign-in/magic-link flows now expose role="alert".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->