### PR TITLE
feat: add Bedrock access key, Vertex service account, and Azure OpenAI support

### DIFF
--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -54,7 +54,7 @@ const ApiKeyProviderConfig = t.Object({
 });
 
 const AzureProviderConfig = t.Object({
-  authMode: t.Literal("api-key"),
+  authMode: t.Literal("azure-api-key"),
   apiKey: t.String({ "x-redact": true }),
   resourceName: t.String(),
   apiVersion: t.Optional(t.String()),

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -48,10 +48,12 @@ const VertexServiceAccountConfig = t.Object({
 const VertexProviderConfig = t.Union([VertexIdentityFederationConfig, VertexServiceAccountConfig]);
 
 const ApiKeyProviderConfig = t.Object({
+  authMode: t.Literal("api-key"),
   apiKey: t.String({ "x-redact": true }),
 });
 
 const AzureProviderConfig = t.Object({
+  authMode: t.Literal("api-key"),
   apiKey: t.String({ "x-redact": true }),
   resourceName: t.String(),
   apiVersion: t.Optional(t.String()),

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -40,7 +40,8 @@ const VertexIdentityFederationConfig = t.Object({
 
 const VertexServiceAccountConfig = t.Object({
   authMode: t.Literal("service-account"),
-  serviceAccountKey: t.String({ "x-redact": true }),
+  clientEmail: t.String(),
+  privateKey: t.String({ "x-redact": true }),
   location: t.String(),
   project: t.String(),
 });

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -21,17 +21,17 @@ const BedrockIamRoleConfig = t.Object({
   region: t.String(),
 });
 
-const BedrockStaticConfig = t.Object({
-  authMode: t.Literal("static"),
+const BedrockAccessKeyConfig = t.Object({
+  authMode: t.Literal("access-key"),
   accessKeyId: t.String({ "x-redact": true }),
   secretAccessKey: t.String({ "x-redact": true }),
   region: t.String(),
 });
 
-const BedrockProviderConfig = t.Union([BedrockIamRoleConfig, BedrockStaticConfig]);
+const BedrockProviderConfig = t.Union([BedrockIamRoleConfig, BedrockAccessKeyConfig]);
 
-const VertexWifConfig = t.Object({
-  authMode: t.Literal("wif"),
+const VertexIdentityFederationConfig = t.Object({
+  authMode: t.Literal("identity-federation"),
   serviceAccountEmail: t.String(),
   audience: t.String(),
   location: t.String(),
@@ -45,7 +45,7 @@ const VertexServiceAccountConfig = t.Object({
   project: t.String(),
 });
 
-const VertexProviderConfig = t.Union([VertexWifConfig, VertexServiceAccountConfig]);
+const VertexProviderConfig = t.Union([VertexIdentityFederationConfig, VertexServiceAccountConfig]);
 
 const ApiKeyProviderConfig = t.Object({
   apiKey: t.String({ "x-redact": true }),
@@ -82,9 +82,9 @@ export const Models = t.Array(
 
 export type Models = Static<typeof Models>;
 export type BedrockIamRoleConfig = Static<typeof BedrockIamRoleConfig>;
-export type BedrockStaticConfig = Static<typeof BedrockStaticConfig>;
+export type BedrockAccessKeyConfig = Static<typeof BedrockAccessKeyConfig>;
 export type BedrockProviderConfig = Static<typeof BedrockProviderConfig>;
-export type VertexWifConfig = Static<typeof VertexWifConfig>;
+export type VertexIdentityFederationConfig = Static<typeof VertexIdentityFederationConfig>;
 export type VertexServiceAccountConfig = Static<typeof VertexServiceAccountConfig>;
 export type VertexProviderConfig = Static<typeof VertexProviderConfig>;
 export type ApiKeyProviderConfig = Static<typeof ApiKeyProviderConfig>;

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -57,7 +57,6 @@ const AzureProviderConfig = t.Object({
   authMode: t.Literal("azure-api-key"),
   apiKey: t.String({ "x-redact": true }),
   resourceName: t.String(),
-  apiVersion: t.Optional(t.String()),
 });
 
 export const ProviderConfig = t.Union([

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -2,6 +2,7 @@ import { t, type Static } from "elysia";
 
 export const supportedProviders = {
   anthropic: { name: "Anthropic" },
+  azure: { name: "Azure OpenAI" },
   bedrock: { name: "Amazon Bedrock" },
   groq: { name: "Groq" },
   openai: { name: "OpenAI" },
@@ -14,26 +15,53 @@ export const ProviderSlug = t.Enum(
   { error: "Invalid provider slug" },
 );
 
-const BedrockProviderConfig = t.Object({
+const BedrockIamRoleConfig = t.Object({
+  authMode: t.Literal("iam-role"),
   bedrockRoleArn: t.String(),
   region: t.String(),
 });
 
-const VertexProviderConfig = t.Object({
+const BedrockStaticConfig = t.Object({
+  authMode: t.Literal("static"),
+  accessKeyId: t.String({ "x-redact": true }),
+  secretAccessKey: t.String({ "x-redact": true }),
+  region: t.String(),
+});
+
+const BedrockProviderConfig = t.Union([BedrockIamRoleConfig, BedrockStaticConfig]);
+
+const VertexWifConfig = t.Object({
+  authMode: t.Literal("wif"),
   serviceAccountEmail: t.String(),
   audience: t.String(),
   location: t.String(),
   project: t.String(),
 });
 
+const VertexServiceAccountConfig = t.Object({
+  authMode: t.Literal("service-account"),
+  serviceAccountKey: t.String({ "x-redact": true }),
+  location: t.String(),
+  project: t.String(),
+});
+
+const VertexProviderConfig = t.Union([VertexWifConfig, VertexServiceAccountConfig]);
+
 const ApiKeyProviderConfig = t.Object({
   apiKey: t.String({ "x-redact": true }),
+});
+
+const AzureProviderConfig = t.Object({
+  apiKey: t.String({ "x-redact": true }),
+  resourceName: t.String(),
+  apiVersion: t.Optional(t.String()),
 });
 
 export const ProviderConfig = t.Union([
   BedrockProviderConfig,
   VertexProviderConfig,
   ApiKeyProviderConfig,
+  AzureProviderConfig,
 ]);
 
 export const Provider = t.Object({
@@ -53,9 +81,14 @@ export const Models = t.Array(
 );
 
 export type Models = Static<typeof Models>;
+export type BedrockIamRoleConfig = Static<typeof BedrockIamRoleConfig>;
+export type BedrockStaticConfig = Static<typeof BedrockStaticConfig>;
 export type BedrockProviderConfig = Static<typeof BedrockProviderConfig>;
+export type VertexWifConfig = Static<typeof VertexWifConfig>;
+export type VertexServiceAccountConfig = Static<typeof VertexServiceAccountConfig>;
 export type VertexProviderConfig = Static<typeof VertexProviderConfig>;
 export type ApiKeyProviderConfig = Static<typeof ApiKeyProviderConfig>;
+export type AzureProviderConfig = Static<typeof AzureProviderConfig>;
 export type Provider = Static<typeof Provider>;
 export type ProviderConfig = Static<typeof ProviderConfig>;
 export type ProviderSlug = Static<typeof ProviderSlug>;

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -54,9 +54,9 @@ const ApiKeyProviderConfig = t.Object({
 });
 
 const AzureProviderConfig = t.Object({
-  authMode: t.Literal("azure-api-key"),
-  apiKey: t.String({ "x-redact": true }),
+  authMode: t.Literal("resource-api-key"),
   resourceName: t.String(),
+  apiKey: t.String({ "x-redact": true }),
 });
 
 export const ProviderConfig = t.Union([

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -41,7 +41,10 @@ const VertexIdentityFederationConfig = t.Object({
 const VertexServiceAccountConfig = t.Object({
   authMode: t.Literal("service-account"),
   clientEmail: t.String(),
-  privateKey: t.String({ "x-redact": true }),
+  privateKey: t
+    .Transform(t.String({ "x-redact": true }))
+    .Decode((v) => v.replace(/\\n/g, "\n"))
+    .Encode((v) => v),
   location: t.String(),
   project: t.String(),
 });

--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -2,7 +2,7 @@ import { t, type Static } from "elysia";
 
 export const supportedProviders = {
   anthropic: { name: "Anthropic" },
-  azure: { name: "Azure OpenAI" },
+  azure: { name: "Microsoft Azure" },
   bedrock: { name: "Amazon Bedrock" },
   groq: { name: "Groq" },
   openai: { name: "OpenAI" },

--- a/apps/console/app/lib/utils.ts
+++ b/apps/console/app/lib/utils.ts
@@ -30,7 +30,10 @@ export const formatDateTime = (date: Date) => {
   });
 };
 
-// Create human readable labels, e.g. "serviceAccount" => "Service Account"
+// Create human readable labels, e.g. "serviceAccount" => "Service Account", "iam-role" => "Iam Role"
 export function labelize(value: string) {
-  return value.replaceAll(/([a-z\d])([A-Z])/g, "$1 $2").replace(/^\w/, (c) => c.toUpperCase());
+  return value
+    .replaceAll(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replaceAll("-", " ")
+    .replaceAll(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/apps/console/app/mocks/routes/providers.ts
+++ b/apps/console/app/mocks/routes/providers.ts
@@ -4,7 +4,7 @@ import { db } from "~console/mocks/db";
 
 const SUPPORTED_PROVIDERS: Record<string, { name: string }> = {
   anthropic: { name: "Anthropic" },
-  azure: { name: "Azure OpenAI" },
+  azure: { name: "Microsoft Azure" },
   bedrock: { name: "Amazon Bedrock" },
   groq: { name: "Groq" },
   openai: { name: "OpenAI" },

--- a/apps/console/app/mocks/routes/providers.ts
+++ b/apps/console/app/mocks/routes/providers.ts
@@ -4,6 +4,7 @@ import { db } from "~console/mocks/db";
 
 const SUPPORTED_PROVIDERS: Record<string, { name: string }> = {
   anthropic: { name: "Anthropic" },
+  azure: { name: "Azure OpenAI" },
   bedrock: { name: "Amazon Bedrock" },
   groq: { name: "Groq" },
   openai: { name: "OpenAI" },

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -53,7 +53,8 @@ const VertexIdentityFederationSchema = z.object({
 
 const VertexServiceAccountSchema = z.object({
   authMode: z.literal("service-account"),
-  serviceAccountKey: requiredString("Please enter the service account JSON key"),
+  clientEmail: z.email("Please enter a valid service account email").trim().min(1),
+  privateKey: requiredString("Please enter the private key"),
   location: requiredString("Please enter a valid location"),
   project: requiredString("Please enter a valid project"),
 });
@@ -121,12 +122,12 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
   const slug = provider?.slug ?? "";
   const modes = getProviderModes(slug);
   const hasTabs = modes.length > 1;
-  const initialAuthMode = (provider?.config?.authMode as string) ?? modes[0].value;
-  const [activeAuthMode, setActiveAuthMode] = useState(initialAuthMode);
+  const defaultAuthMode = (provider?.config?.authMode as string | undefined) ?? modes[0]?.value ?? "";
+  const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
 
   useEffect(() => {
-    setActiveAuthMode((provider?.config?.authMode as string) ?? modes[0].value);
-  }, [provider?.slug, provider?.config?.authMode, modes]);
+    setActiveAuthMode(defaultAuthMode);
+  }, [slug, defaultAuthMode]);
 
   const [form, fields] = useForm<ProviderConfigureFormValues>({
     id: `${slug}-${activeAuthMode ?? "default"}`,
@@ -147,7 +148,7 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
 
   const configFieldset = fields.config.getFieldset();
   const activeMode = modes.find((m) => m.value === activeAuthMode) ?? modes[0];
-  const activeKeys = provider ? getConfigFields(activeMode.schema) : [];
+  const activeKeys = provider && activeMode ? getConfigFields(activeMode.schema) : [];
 
   const renderFields = () => (
     <FieldGroup>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -93,24 +93,25 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
-const providerAuthModes: Record<
-  string,
-  { value: string; label: string; schema: z.ZodObject<z.ZodRawShape> }[]
-> = {
-  bedrock: [
-    { value: "iam-role", label: "IAM Role", schema: BedrockIamRoleSchema },
-    { value: "static", label: "Static Credentials", schema: BedrockStaticSchema },
-  ],
-  vertex: [
-    { value: "wif", label: "Workload Identity", schema: VertexWifSchema },
-    { value: "service-account", label: "Service Account", schema: VertexServiceAccountSchema },
-  ],
-  azure: [{ value: "default", label: "API Key", schema: AzureSchema }],
-  anthropic: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
-  openai: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
-  groq: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
-  voyage: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
-};
+function getProviderModes(slug: string) {
+  const entry = ProviderConfigureSchema.options.find((o) => {
+    const s = o.shape.slug;
+    // z.enum exposes .options, z.literal exposes .value at runtime
+    return "options" in s
+      ? (s.options as string[]).includes(slug)
+      : (s as unknown as { value: string }).value === slug;
+  });
+  if (!entry) return [];
+
+  const configSchema = entry.shape.config;
+  if (configSchema instanceof z.ZodDiscriminatedUnion) {
+    return [...configSchema.options].map((opt) => {
+      const value = (opt.shape.authMode as z.ZodLiteral<string>).value;
+      return { value, label: labelize(value), schema: opt as z.ZodObject<z.ZodRawShape> };
+    });
+  }
+  return [{ value: "default", label: "Default", schema: configSchema as z.ZodObject<z.ZodRawShape> }];
+}
 
 function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
   return Object.keys(schema.shape).filter((k) => k !== "authMode");
@@ -119,7 +120,7 @@ function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
   const fetcher = useFetcher();
   const slug = provider?.slug ?? "";
-  const modes = providerAuthModes[slug] ?? [];
+  const modes = getProviderModes(slug);
   const hasTabs = modes.length > 1;
   const initialAuthMode = (provider?.config?.authMode as string) ?? modes[0].value;
   const [activeAuthMode, setActiveAuthMode] = useState(initialAuthMode);

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -169,13 +169,11 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
         </FieldControl>
       </Field>
 
-      {"authMode" in configFieldset && (
-        <Field name={configFieldset.authMode.name} className="hidden">
-          <FieldControl>
-            <input type="hidden" value={activeAuthMode} />
-          </FieldControl>
-        </Field>
-      )}
+      <Field name={configFieldset.authMode.name} className="hidden">
+        <FieldControl>
+          <input type="hidden" value={activeAuthMode} />
+        </FieldControl>
+      </Field>
 
       {(activeKeys as (keyof typeof configFieldset)[]).map((key) => {
         const field = configFieldset[key];

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -36,15 +36,15 @@ const BedrockIamRoleSchema = z.object({
   region: requiredString("Please enter a valid AWS region"),
 });
 
-const BedrockStaticSchema = z.object({
-  authMode: z.literal("static"),
+const BedrockAccessKeySchema = z.object({
+  authMode: z.literal("access-key"),
   accessKeyId: requiredString("Please enter a valid access key ID"),
   secretAccessKey: requiredString("Please enter a valid secret access key"),
   region: requiredString("Please enter a valid AWS region"),
 });
 
-const VertexWifSchema = z.object({
-  authMode: z.literal("wif"),
+const VertexIdentityFederationSchema = z.object({
+  authMode: z.literal("identity-federation"),
   serviceAccountEmail: z.email("Please enter a valid service account email").trim().min(1),
   audience: requiredString("Please enter a valid audience"),
   location: requiredString("Please enter a valid location"),
@@ -71,11 +71,11 @@ const ApiKeySchema = z.object({
 export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   z.object({
     slug: z.enum(["bedrock"]),
-    config: z.discriminatedUnion("authMode", [BedrockIamRoleSchema, BedrockStaticSchema]),
+    config: z.discriminatedUnion("authMode", [BedrockIamRoleSchema, BedrockAccessKeySchema]),
   }),
   z.object({
     slug: z.enum(["vertex"]),
-    config: z.discriminatedUnion("authMode", [VertexWifSchema, VertexServiceAccountSchema]),
+    config: z.discriminatedUnion("authMode", [VertexIdentityFederationSchema, VertexServiceAccountSchema]),
   }),
   z.object({
     slug: z.enum(["azure"]),

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -58,6 +58,16 @@ const VertexServiceAccountSchema = z.object({
   project: requiredString("Please enter a valid project"),
 });
 
+const AzureSchema = z.object({
+  apiKey: requiredString("Please enter a valid API key"),
+  resourceName: requiredString("Please enter a valid resource name"),
+  apiVersion: z.string().optional(),
+});
+
+const ApiKeySchema = z.object({
+  apiKey: requiredString("Please enter a valid API key"),
+});
+
 export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   z.object({
     slug: z.enum(["bedrock"]),
@@ -69,17 +79,11 @@ export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   }),
   z.object({
     slug: z.enum(["azure"]),
-    config: z.object({
-      apiKey: requiredString("Please enter a valid API key"),
-      resourceName: requiredString("Please enter a valid resource name"),
-      apiVersion: z.string().optional(),
-    }),
+    config: AzureSchema,
   }),
   z.object({
     slug: z.enum(["voyage", "groq", "anthropic", "openai"]),
-    config: z.object({
-      apiKey: requiredString("Please enter a valid API key"),
-    }),
+    config: ApiKeySchema,
   }),
 ]);
 
@@ -89,51 +93,41 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
-const authModes: Record<string, { modes: { value: string; label: string }[] }> = {
-  bedrock: {
-    modes: [
-      { value: "iam-role", label: "IAM Role" },
-      { value: "static", label: "Static Credentials" },
-    ],
-  },
-  vertex: {
-    modes: [
-      { value: "wif", label: "Workload Identity" },
-      { value: "service-account", label: "Service Account" },
-    ],
-  },
+type AuthModeEntry = { value: string; label: string; schema: z.ZodObject<z.ZodRawShape> };
+
+const providerAuthModes: Record<string, AuthModeEntry[]> = {
+  bedrock: [
+    { value: "iam-role", label: "IAM Role", schema: BedrockIamRoleSchema },
+    { value: "static", label: "Static Credentials", schema: BedrockStaticSchema },
+  ],
+  vertex: [
+    { value: "wif", label: "Workload Identity", schema: VertexWifSchema },
+    { value: "service-account", label: "Service Account", schema: VertexServiceAccountSchema },
+  ],
+  azure: [{ value: "default", label: "API Key", schema: AzureSchema }],
 };
 
-function getConfigFields(slug: string, authMode?: string): string[] {
-  switch (slug) {
-    case "bedrock":
-      return authMode === "static"
-        ? ["accessKeyId", "secretAccessKey", "region"]
-        : ["bedrockRoleArn", "region"];
-    case "vertex":
-      return authMode === "service-account"
-        ? ["serviceAccountKey", "location", "project"]
-        : ["serviceAccountEmail", "audience", "location", "project"];
-    case "azure":
-      return ["apiKey", "resourceName", "apiVersion"];
-    default:
-      return ["apiKey"];
-  }
+const defaultAuthModes: AuthModeEntry[] = [{ value: "default", label: "Default", schema: ApiKeySchema }];
+
+function getAuthModes(slug: string): AuthModeEntry[] {
+  return providerAuthModes[slug] ?? defaultAuthModes;
+}
+
+function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
+  return Object.keys(schema.shape).filter((k) => k !== "authMode");
 }
 
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
   const fetcher = useFetcher();
   const slug = provider?.slug ?? "";
-  const providerAuthModes = authModes[slug];
-  const defaultAuthMode =
-    (provider?.config?.authMode as string) ?? providerAuthModes?.modes[0]?.value;
-  const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
+  const modes = getAuthModes(slug);
+  const hasTabs = modes.length > 1;
+  const initialAuthMode = (provider?.config?.authMode as string) ?? modes[0].value;
+  const [activeAuthMode, setActiveAuthMode] = useState(initialAuthMode);
 
   useEffect(() => {
-    setActiveAuthMode(
-      (provider?.config?.authMode as string) ?? providerAuthModes?.modes[0]?.value,
-    );
-  }, [provider?.slug, provider?.config?.authMode, providerAuthModes]);
+    setActiveAuthMode((provider?.config?.authMode as string) ?? modes[0].value);
+  }, [provider?.slug, provider?.config?.authMode, modes]);
 
   const [form, fields] = useForm<ProviderConfigureFormValues>({
     id: `${slug}-${activeAuthMode ?? "default"}`,
@@ -153,7 +147,8 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
   }, [fetcher.state, form.status]);
 
   const configFieldset = fields.config.getFieldset();
-  const activeKeys = provider ? getConfigFields(slug, activeAuthMode) : [];
+  const activeMode = modes.find((m) => m.value === activeAuthMode) ?? modes[0];
+  const activeKeys = provider ? getConfigFields(activeMode.schema) : [];
 
   const renderFields = () => (
     <FieldGroup>
@@ -163,7 +158,7 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
         </FieldControl>
       </Field>
 
-      {providerAuthModes && "authMode" in configFieldset && (
+      {hasTabs && "authMode" in configFieldset && (
         <Field name={configFieldset.authMode.name} className="hidden">
           <FieldControl>
             <input type="hidden" value={activeAuthMode} />
@@ -198,16 +193,16 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
             </DialogDescription>
           </DialogHeader>
 
-          {providerAuthModes ? (
+          {hasTabs ? (
             <Tabs value={activeAuthMode} onValueChange={setActiveAuthMode}>
               <TabsList>
-                {providerAuthModes.modes.map((mode) => (
+                {modes.map((mode) => (
                   <TabsTrigger key={mode.value} value={mode.value}>
                     {mode.label}
                   </TabsTrigger>
                 ))}
               </TabsList>
-              {providerAuthModes.modes.map((mode) => (
+              {modes.map((mode) => (
                 <TabsContent key={mode.value} value={mode.value}>
                   {activeAuthMode === mode.value && renderFields()}
                 </TabsContent>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -29,7 +29,7 @@ import { useFormErrorToast } from "~console/lib/errors";
 import { labelize } from "~console/lib/utils";
 
 const requiredString = (msg: string) => z.string(msg).trim().min(1, msg);
-const textareaString = (msg: string) => Object.assign(requiredString(msg), { textarea: true as const });
+const textareaString = (msg: string) => requiredString(msg).meta({ textarea: true });
 
 const BedrockIamRoleSchema = z.object({
   authMode: z.literal("iam-role"),
@@ -119,7 +119,9 @@ function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
 
 function isTextarea(schema: z.ZodObject<z.ZodRawShape>, key: string): boolean {
   const field = schema.shape[key];
-  return field != null && "textarea" in field && field.textarea === true;
+  if (!field) return false;
+  const meta = z.globalRegistry.get(field);
+  return meta?.textarea === true;
 }
 
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
@@ -127,7 +129,9 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
   const slug = provider?.slug ?? "";
   const modes = getProviderModes(slug);
   const hasTabs = modes.length > 1;
-  const defaultAuthMode = (provider?.config?.authMode as string | undefined) ?? modes[0]?.value ?? "";
+  const rawAuthMode = provider?.config?.authMode as string | undefined;
+  const defaultAuthMode =
+    rawAuthMode && modes.some((m) => m.value === rawAuthMode) ? rawAuthMode : (modes[0]?.value ?? "");
   const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
 
   useEffect(() => {

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -80,7 +80,10 @@ export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   }),
   z.object({
     slug: z.enum(["vertex"]),
-    config: z.discriminatedUnion("authMode", [VertexIdentityFederationSchema, VertexServiceAccountSchema]),
+    config: z.discriminatedUnion("authMode", [
+      VertexIdentityFederationSchema,
+      VertexServiceAccountSchema,
+    ]),
   }),
   z.object({
     slug: z.enum(["azure"]),
@@ -98,6 +101,9 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
+type ConfigSchemaOption =
+  (typeof ProviderConfigureSchema.options)[number]["shape"]["config"]["options"][number];
+
 function getProviderModes(slug: string) {
   const entry = ProviderConfigureSchema.options.find((o) => {
     const s = o.shape.slug;
@@ -108,20 +114,18 @@ function getProviderModes(slug: string) {
   });
   if (!entry) return [];
 
-  const configSchema = entry.shape.config as z.ZodDiscriminatedUnion<string, z.ZodObject<z.ZodRawShape>[]>;
-  return [...configSchema.options].map((opt) => {
-    const value = (opt.shape.authMode as z.ZodLiteral<string>).value;
-    return { value, label: labelize(value), schema: opt as z.ZodObject<z.ZodRawShape> };
+  return entry.shape.config.options.map((opt) => {
+    const value = opt.shape.authMode.value;
+    return { value, label: labelize(value), schema: opt };
   });
 }
 
-function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
+function getConfigFields(schema: ConfigSchemaOption): string[] {
   return Object.keys(schema.shape).filter((k) => k !== "authMode");
 }
 
-function isTextarea(schema: z.ZodObject<z.ZodRawShape>, key: string): boolean {
-  const field = schema.shape[key];
-  if (!field) return false;
+function isTextarea(schema: ConfigSchemaOption, key: string): boolean {
+  const field = schema.shape[key as keyof typeof schema.shape];
   return field.meta()?.textarea === true;
 }
 
@@ -132,7 +136,9 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
   const hasTabs = modes.length > 1;
   const rawAuthMode = provider?.config?.authMode as string | undefined;
   const defaultAuthMode =
-    rawAuthMode && modes.some((m) => m.value === rawAuthMode) ? rawAuthMode : (modes[0]?.value ?? "");
+    rawAuthMode && modes.some((m) => m.value === rawAuthMode)
+      ? rawAuthMode
+      : (modes[0]?.value ?? "");
   const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
 
   useEffect(() => {

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -24,6 +24,7 @@ import {
 } from "@hebo/shared-ui/components/Field";
 import { Input } from "@hebo/shared-ui/components/Input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@hebo/shared-ui/components/Tabs";
+import { Textarea } from "@hebo/shared-ui/components/Textarea";
 
 import { useFormErrorToast } from "~console/lib/errors";
 import { labelize } from "~console/lib/utils";
@@ -183,11 +184,10 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
             <FieldLabel>{labelize(key)}</FieldLabel>
             <FieldControl>
               {activeMode && isTextarea(activeMode.schema, key) ? (
-                <textarea
+                <Textarea
                   placeholder={`Set ${labelize(key).toLowerCase()}`}
                   autoComplete="off"
                   rows={4}
-                  className="w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 bg-background"
                 />
               ) : (
                 <Input placeholder={`Set ${labelize(key).toLowerCase()}`} autoComplete="off" />

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -60,7 +60,7 @@ const VertexServiceAccountSchema = z.object({
 });
 
 const AzureSchema = z.object({
-  authMode: z.literal("api-key"),
+  authMode: z.literal("azure-api-key"),
   apiKey: requiredString("Please enter a valid API key"),
   resourceName: requiredString("Please enter a valid resource name"),
   apiVersion: z.string().optional(),

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -120,8 +120,7 @@ function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
 function isTextarea(schema: z.ZodObject<z.ZodRawShape>, key: string): boolean {
   const field = schema.shape[key];
   if (!field) return false;
-  const meta = z.globalRegistry.get(field);
-  return meta?.textarea === true;
+  return field.meta()?.textarea === true;
 }
 
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -101,9 +101,6 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
-type ConfigSchemaOption =
-  (typeof ProviderConfigureSchema.options)[number]["shape"]["config"]["options"][number];
-
 function getProviderModes(slug: string) {
   const entry = ProviderConfigureSchema.options.find((o) => {
     const s = o.shape.slug;
@@ -120,33 +117,31 @@ function getProviderModes(slug: string) {
   });
 }
 
-function getConfigFields(schema: ConfigSchemaOption): string[] {
+function getConfigFields(schema: z.ZodObject): string[] {
   return Object.keys(schema.shape).filter((k) => k !== "authMode");
 }
 
-function isTextarea(schema: ConfigSchemaOption, key: string): boolean {
+function isTextarea(schema: z.ZodObject, key: string): boolean {
   const field = schema.shape[key as keyof typeof schema.shape];
   return field.meta()?.textarea === true;
 }
 
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
   const fetcher = useFetcher();
-  const slug = provider?.slug ?? "";
-  const modes = getProviderModes(slug);
-  const hasTabs = modes.length > 1;
-  const rawAuthMode = provider?.config?.authMode as string | undefined;
+
+  const modes = getProviderModes(provider?.slug ?? "");
+
   const defaultAuthMode =
-    rawAuthMode && modes.some((m) => m.value === rawAuthMode)
-      ? rawAuthMode
-      : (modes[0]?.value ?? "");
+    modes.find((m) => m.value === provider?.config?.authMode)?.value ?? modes[0]?.value ?? "";
+
   const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
 
   useEffect(() => {
     setActiveAuthMode(defaultAuthMode);
-  }, [slug, defaultAuthMode]);
+  }, [defaultAuthMode]);
 
   const [form, fields] = useForm<ProviderConfigureFormValues>({
-    id: `${slug}-${activeAuthMode ?? "default"}`,
+    id: `${provider?.slug}-${activeAuthMode ?? "default"}`,
     lastResult: fetcher.state === "idle" ? fetcher.data?.submission : undefined,
     constraint: getZodConstraint(ProviderConfigureSchema),
     defaultValue: {
@@ -217,7 +212,7 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
             </DialogDescription>
           </DialogHeader>
 
-          {hasTabs ? (
+          {modes.length > 1 ? (
             <Tabs value={activeAuthMode} onValueChange={setActiveAuthMode}>
               <TabsList>
                 {modes.map((mode) => (

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -173,7 +173,16 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
           <Field key={key} name={field.name}>
             <FieldLabel>{labelize(key)}</FieldLabel>
             <FieldControl>
-              <Input placeholder={`Set ${labelize(key).toLowerCase()}`} autoComplete="off" />
+              {key === "privateKey" ? (
+                <textarea
+                  placeholder={`Set ${labelize(key).toLowerCase()}`}
+                  autoComplete="off"
+                  rows={4}
+                  className="w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 bg-background"
+                />
+              ) : (
+                <Input placeholder={`Set ${labelize(key).toLowerCase()}`} autoComplete="off" />
+              )}
             </FieldControl>
             <FieldError />
           </Field>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -102,13 +102,9 @@ type ConfigureProviderDialogProps = {
 } & React.ComponentProps<typeof Dialog>;
 
 function getProviderModes(slug: string) {
-  const entry = ProviderConfigureSchema.options.find((o) => {
-    const s = o.shape.slug;
-    // z.enum exposes .options, z.literal exposes .value at runtime
-    return "options" in s
-      ? (s.options as string[]).includes(slug)
-      : (s as unknown as { value: string }).value === slug;
-  });
+  const entry = ProviderConfigureSchema.options.find((o) =>
+    (o.shape.slug.options as string[]).includes(slug),
+  );
   if (!entry) return [];
 
   return entry.shape.config.options.map((opt) => {
@@ -177,12 +173,11 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
 
       {(activeKeys as (keyof typeof configFieldset)[]).map((key) => {
         const field = configFieldset[key];
-        if (!field) return null;
         return (
           <Field key={key} name={field.name}>
             <FieldLabel>{labelize(key)}</FieldLabel>
             <FieldControl>
-              {activeMode && isTextarea(activeMode.schema, key) ? (
+              {isTextarea(activeMode.schema, key) ? (
                 <Textarea
                   placeholder={`Set ${labelize(key).toLowerCase()}`}
                   autoComplete="off"

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -59,12 +59,14 @@ const VertexServiceAccountSchema = z.object({
 });
 
 const AzureSchema = z.object({
+  authMode: z.literal("api-key"),
   apiKey: requiredString("Please enter a valid API key"),
   resourceName: requiredString("Please enter a valid resource name"),
   apiVersion: z.string().optional(),
 });
 
 const ApiKeySchema = z.object({
+  authMode: z.literal("api-key"),
   apiKey: requiredString("Please enter a valid API key"),
 });
 
@@ -79,11 +81,11 @@ export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   }),
   z.object({
     slug: z.enum(["azure"]),
-    config: AzureSchema,
+    config: z.discriminatedUnion("authMode", [AzureSchema]),
   }),
   z.object({
     slug: z.enum(["voyage", "groq", "anthropic", "openai"]),
-    config: ApiKeySchema,
+    config: z.discriminatedUnion("authMode", [ApiKeySchema]),
   }),
 ]);
 
@@ -103,14 +105,11 @@ function getProviderModes(slug: string) {
   });
   if (!entry) return [];
 
-  const configSchema = entry.shape.config;
-  if (configSchema instanceof z.ZodDiscriminatedUnion) {
-    return [...configSchema.options].map((opt) => {
-      const value = (opt.shape.authMode as z.ZodLiteral<string>).value;
-      return { value, label: labelize(value), schema: opt as z.ZodObject<z.ZodRawShape> };
-    });
-  }
-  return [{ value: "default", label: "Default", schema: configSchema as z.ZodObject<z.ZodRawShape> }];
+  const configSchema = entry.shape.config as z.ZodDiscriminatedUnion<string, z.ZodObject<z.ZodRawShape>[]>;
+  return [...configSchema.options].map((opt) => {
+    const value = (opt.shape.authMode as z.ZodLiteral<string>).value;
+    return { value, label: labelize(value), schema: opt as z.ZodObject<z.ZodRawShape> };
+  });
 }
 
 function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
@@ -158,7 +157,7 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
         </FieldControl>
       </Field>
 
-      {hasTabs && "authMode" in configFieldset && (
+      {"authMode" in configFieldset && (
         <Field name={configFieldset.authMode.name} className="hidden">
           <FieldControl>
             <input type="hidden" value={activeAuthMode} />

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -93,9 +93,10 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
-type AuthModeEntry = { value: string; label: string; schema: z.ZodObject<z.ZodRawShape> };
-
-const providerAuthModes: Record<string, AuthModeEntry[]> = {
+const providerAuthModes: Record<
+  string,
+  { value: string; label: string; schema: z.ZodObject<z.ZodRawShape> }[]
+> = {
   bedrock: [
     { value: "iam-role", label: "IAM Role", schema: BedrockIamRoleSchema },
     { value: "static", label: "Static Credentials", schema: BedrockStaticSchema },
@@ -105,13 +106,11 @@ const providerAuthModes: Record<string, AuthModeEntry[]> = {
     { value: "service-account", label: "Service Account", schema: VertexServiceAccountSchema },
   ],
   azure: [{ value: "default", label: "API Key", schema: AzureSchema }],
+  anthropic: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
+  openai: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
+  groq: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
+  voyage: [{ value: "default", label: "API Key", schema: ApiKeySchema }],
 };
-
-const defaultAuthModes: AuthModeEntry[] = [{ value: "default", label: "Default", schema: ApiKeySchema }];
-
-function getAuthModes(slug: string): AuthModeEntry[] {
-  return providerAuthModes[slug] ?? defaultAuthModes;
-}
 
 function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
   return Object.keys(schema.shape).filter((k) => k !== "authMode");
@@ -120,7 +119,7 @@ function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
   const fetcher = useFetcher();
   const slug = provider?.slug ?? "";
-  const modes = getAuthModes(slug);
+  const modes = providerAuthModes[slug] ?? [];
   const hasTabs = modes.length > 1;
   const initialAuthMode = (provider?.config?.authMode as string) ?? modes[0].value;
   const [activeAuthMode, setActiveAuthMode] = useState(initialAuthMode);

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import { z } from "zod";
 
@@ -23,35 +23,62 @@ import {
   FieldGroup,
 } from "@hebo/shared-ui/components/Field";
 import { Input } from "@hebo/shared-ui/components/Input";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@hebo/shared-ui/components/Tabs";
 
 import { useFormErrorToast } from "~console/lib/errors";
 import { labelize } from "~console/lib/utils";
 
+const requiredString = (msg: string) => z.string(msg).trim().min(1, msg);
+
+const BedrockIamRoleSchema = z.object({
+  authMode: z.literal("iam-role"),
+  bedrockRoleArn: requiredString("Please enter a valid Bedrock ARN role"),
+  region: requiredString("Please enter a valid AWS region"),
+});
+
+const BedrockStaticSchema = z.object({
+  authMode: z.literal("static"),
+  accessKeyId: requiredString("Please enter a valid access key ID"),
+  secretAccessKey: requiredString("Please enter a valid secret access key"),
+  region: requiredString("Please enter a valid AWS region"),
+});
+
+const VertexWifSchema = z.object({
+  authMode: z.literal("wif"),
+  serviceAccountEmail: z.email("Please enter a valid service account email").trim().min(1),
+  audience: requiredString("Please enter a valid audience"),
+  location: requiredString("Please enter a valid location"),
+  project: requiredString("Please enter a valid project"),
+});
+
+const VertexServiceAccountSchema = z.object({
+  authMode: z.literal("service-account"),
+  serviceAccountKey: requiredString("Please enter the service account JSON key"),
+  location: requiredString("Please enter a valid location"),
+  project: requiredString("Please enter a valid project"),
+});
+
 export const ProviderConfigureSchema = z.discriminatedUnion("slug", [
   z.object({
     slug: z.enum(["bedrock"]),
-    config: z.object({
-      bedrockRoleArn: ((msg) => z.string(msg).trim().min(1, msg))(
-        "Please enter a valid Bedrock ARN role",
-      ),
-      region: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a valid AWS region"),
-    }),
+    config: z.discriminatedUnion("authMode", [BedrockIamRoleSchema, BedrockStaticSchema]),
   }),
   z.object({
     slug: z.enum(["vertex"]),
+    config: z.discriminatedUnion("authMode", [VertexWifSchema, VertexServiceAccountSchema]),
+  }),
+  z.object({
+    slug: z.enum(["azure"]),
     config: z.object({
-      serviceAccountEmail: ((msg) => z.email(msg).trim().min(1, msg))(
-        "Please enter a valid service account email",
-      ),
-      audience: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a valid audience"),
-      location: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a valid location"),
-      project: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a valid project"),
+      apiKey: requiredString("Please enter a valid API key"),
+      resourceName: requiredString("Please enter a valid resource name"),
+      apiVersion: z.string().optional(),
     }),
   }),
   z.object({
     slug: z.enum(["voyage", "groq", "anthropic", "openai"]),
     config: z.object({
-      apiKey: ((msg) => z.string(msg).trim().min(1, msg))("Please enter a valid API key"),
+      apiKey: requiredString("Please enter a valid API key"),
     }),
   }),
 ]);
@@ -62,11 +89,54 @@ type ConfigureProviderDialogProps = {
   provider?: { name: string; slug: string; config?: Record<string, unknown> };
 } & React.ComponentProps<typeof Dialog>;
 
+const authModes: Record<string, { modes: { value: string; label: string }[] }> = {
+  bedrock: {
+    modes: [
+      { value: "iam-role", label: "IAM Role" },
+      { value: "static", label: "Static Credentials" },
+    ],
+  },
+  vertex: {
+    modes: [
+      { value: "wif", label: "Workload Identity" },
+      { value: "service-account", label: "Service Account" },
+    ],
+  },
+};
+
+function getConfigFields(slug: string, authMode?: string): string[] {
+  switch (slug) {
+    case "bedrock":
+      return authMode === "static"
+        ? ["accessKeyId", "secretAccessKey", "region"]
+        : ["bedrockRoleArn", "region"];
+    case "vertex":
+      return authMode === "service-account"
+        ? ["serviceAccountKey", "location", "project"]
+        : ["serviceAccountEmail", "audience", "location", "project"];
+    case "azure":
+      return ["apiKey", "resourceName", "apiVersion"];
+    default:
+      return ["apiKey"];
+  }
+}
+
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
   const fetcher = useFetcher();
+  const slug = provider?.slug ?? "";
+  const providerAuthModes = authModes[slug];
+  const defaultAuthMode =
+    (provider?.config?.authMode as string) ?? providerAuthModes?.modes[0]?.value;
+  const [activeAuthMode, setActiveAuthMode] = useState(defaultAuthMode);
+
+  useEffect(() => {
+    setActiveAuthMode(
+      (provider?.config?.authMode as string) ?? providerAuthModes?.modes[0]?.value,
+    );
+  }, [provider?.slug, provider?.config?.authMode, providerAuthModes]);
 
   const [form, fields] = useForm<ProviderConfigureFormValues>({
-    id: provider?.slug,
+    id: `${slug}-${activeAuthMode ?? "default"}`,
     lastResult: fetcher.state === "idle" ? fetcher.data?.submission : undefined,
     constraint: getZodConstraint(ProviderConfigureSchema),
     defaultValue: {
@@ -82,16 +152,40 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
     // oxlint-disable-next-line exhaustive-deps
   }, [fetcher.state, form.status]);
 
-  const providerFields = Object.fromEntries(
-    ProviderConfigureSchema.options.flatMap((opt) => {
-      const slugEnum = opt.shape.slug;
-      const configKeys = Object.keys(opt.shape.config.shape);
-      return slugEnum.options.map((slug) => [slug, configKeys]);
-    }),
-  );
-
   const configFieldset = fields.config.getFieldset();
-  const activeKeys = provider ? (providerFields[provider.slug] ?? []) : [];
+  const activeKeys = provider ? getConfigFields(slug, activeAuthMode) : [];
+
+  const renderFields = () => (
+    <FieldGroup>
+      <Field name={fields.slug.name} className="hidden">
+        <FieldControl>
+          <input type="hidden" />
+        </FieldControl>
+      </Field>
+
+      {providerAuthModes && "authMode" in configFieldset && (
+        <Field name={configFieldset.authMode.name} className="hidden">
+          <FieldControl>
+            <input type="hidden" value={activeAuthMode} />
+          </FieldControl>
+        </Field>
+      )}
+
+      {(activeKeys as (keyof typeof configFieldset)[]).map((key) => {
+        const field = configFieldset[key];
+        if (!field) return null;
+        return (
+          <Field key={key} name={field.name}>
+            <FieldLabel>{labelize(key)}</FieldLabel>
+            <FieldControl>
+              <Input placeholder={`Set ${labelize(key).toLowerCase()}`} autoComplete="off" />
+            </FieldControl>
+            <FieldError />
+          </Field>
+        );
+      })}
+    </FieldGroup>
+  );
 
   return (
     <Dialog {...props}>
@@ -104,26 +198,24 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
             </DialogDescription>
           </DialogHeader>
 
-          <FieldGroup>
-            <Field name={fields.slug.name} className="hidden">
-              <FieldControl>
-                <input type="hidden" />
-              </FieldControl>
-            </Field>
-
-            {(activeKeys as (keyof typeof configFieldset)[]).map((key) => {
-              const field = configFieldset[key];
-              return (
-                <Field key={key} name={field.name}>
-                  <FieldLabel>{labelize(key)}</FieldLabel>
-                  <FieldControl>
-                    <Input placeholder={`Set ${labelize(key).toLowerCase()}`} autoComplete="off" />
-                  </FieldControl>
-                  <FieldError />
-                </Field>
-              );
-            })}
-          </FieldGroup>
+          {providerAuthModes ? (
+            <Tabs value={activeAuthMode} onValueChange={setActiveAuthMode}>
+              <TabsList>
+                {providerAuthModes.modes.map((mode) => (
+                  <TabsTrigger key={mode.value} value={mode.value}>
+                    {mode.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {providerAuthModes.modes.map((mode) => (
+                <TabsContent key={mode.value} value={mode.value}>
+                  {activeAuthMode === mode.value && renderFields()}
+                </TabsContent>
+              ))}
+            </Tabs>
+          ) : (
+            renderFields()
+          )}
 
           <div className="text-sm">
             The configured provider will only handle requests after you enable it for a specific

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -63,9 +63,9 @@ const VertexServiceAccountSchema = z.object({
 });
 
 const AzureSchema = z.object({
-  authMode: z.literal("azure-api-key"),
-  apiKey: requiredString("Please enter a valid API key"),
+  authMode: z.literal("resource-api-key"),
   resourceName: requiredString("Please enter a valid resource name"),
+  apiKey: requiredString("Please enter a valid API key"),
 });
 
 const ApiKeySchema = z.object({

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -29,6 +29,7 @@ import { useFormErrorToast } from "~console/lib/errors";
 import { labelize } from "~console/lib/utils";
 
 const requiredString = (msg: string) => z.string(msg).trim().min(1, msg);
+const textareaString = (msg: string) => Object.assign(requiredString(msg), { textarea: true as const });
 
 const BedrockIamRoleSchema = z.object({
   authMode: z.literal("iam-role"),
@@ -54,7 +55,7 @@ const VertexIdentityFederationSchema = z.object({
 const VertexServiceAccountSchema = z.object({
   authMode: z.literal("service-account"),
   clientEmail: z.email("Please enter a valid service account email").trim().min(1),
-  privateKey: requiredString("Please enter the private key"),
+  privateKey: textareaString("Please enter the private key"),
   location: requiredString("Please enter a valid location"),
   project: requiredString("Please enter a valid project"),
 });
@@ -63,7 +64,6 @@ const AzureSchema = z.object({
   authMode: z.literal("azure-api-key"),
   apiKey: requiredString("Please enter a valid API key"),
   resourceName: requiredString("Please enter a valid resource name"),
-  apiVersion: z.string().optional(),
 });
 
 const ApiKeySchema = z.object({
@@ -115,6 +115,11 @@ function getProviderModes(slug: string) {
 
 function getConfigFields(schema: z.ZodObject<z.ZodRawShape>): string[] {
   return Object.keys(schema.shape).filter((k) => k !== "authMode");
+}
+
+function isTextarea(schema: z.ZodObject<z.ZodRawShape>, key: string): boolean {
+  const field = schema.shape[key];
+  return field != null && "textarea" in field && field.textarea === true;
 }
 
 export function ConfigureProviderDialog({ provider, ...props }: ConfigureProviderDialogProps) {
@@ -173,7 +178,7 @@ export function ConfigureProviderDialog({ provider, ...props }: ConfigureProvide
           <Field key={key} name={field.name}>
             <FieldLabel>{labelize(key)}</FieldLabel>
             <FieldControl>
-              {key === "privateKey" ? (
+              {activeMode && isTextarea(activeMode.schema, key) ? (
                 <textarea
                   placeholder={`Set ${labelize(key).toLowerCase()}`}
                   autoComplete="off"

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/configure.tsx
@@ -29,6 +29,7 @@ import { useFormErrorToast } from "~console/lib/errors";
 import { labelize } from "~console/lib/utils";
 
 const requiredString = (msg: string) => z.string(msg).trim().min(1, msg);
+const requiredEmail = (msg: string) => z.string(msg).trim().min(1, msg).email(msg);
 const textareaString = (msg: string) => requiredString(msg).meta({ textarea: true });
 
 const BedrockIamRoleSchema = z.object({
@@ -46,7 +47,7 @@ const BedrockAccessKeySchema = z.object({
 
 const VertexIdentityFederationSchema = z.object({
   authMode: z.literal("identity-federation"),
-  serviceAccountEmail: z.email("Please enter a valid service account email").trim().min(1),
+  serviceAccountEmail: requiredEmail("Please enter a valid service account email"),
   audience: requiredString("Please enter a valid audience"),
   location: requiredString("Please enter a valid location"),
   project: requiredString("Please enter a valid project"),
@@ -54,7 +55,7 @@ const VertexIdentityFederationSchema = z.object({
 
 const VertexServiceAccountSchema = z.object({
   authMode: z.literal("service-account"),
-  clientEmail: z.email("Please enter a valid service account email").trim().min(1),
+  clientEmail: requiredEmail("Please enter a valid service account email"),
   privateKey: textareaString("Please enter the private key"),
   location: requiredString("Please enter a valid location"),
   project: requiredString("Please enter a valid project"),

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/list.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.providers/list.tsx
@@ -17,7 +17,15 @@ import {
   ItemTitle,
 } from "@hebo/shared-ui/components/Item";
 
-import { Anthropic, Bedrock, Groq, OpenAI, Vertex, Voyage } from "~console/components/ui/Icons";
+import {
+  Anthropic,
+  Bedrock,
+  Groq,
+  Microsoft,
+  OpenAI,
+  Vertex,
+  Voyage,
+} from "~console/components/ui/Icons";
 import { formatDateTime } from "~console/lib/utils";
 
 import { ClearCredentialsDialog } from "./clear";
@@ -25,6 +33,7 @@ import { ConfigureProviderDialog } from "./configure";
 
 const ProviderIcons = {
   anthropic: Anthropic,
+  azure: Microsoft,
   bedrock: Bedrock,
   groq: Groq,
   openai: OpenAI,

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/utils.ts
@@ -3,9 +3,8 @@ import prettyMs from "pretty-ms";
 
 function getDecimalSeparator(): string {
   return (
-    new Intl.NumberFormat(undefined)
-      .formatToParts(1.1)
-      .find((p) => p.type === "decimal")?.value ?? "."
+    new Intl.NumberFormat(undefined).formatToParts(1.1).find((p) => p.type === "decimal")?.value ??
+    "."
   );
 }
 

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.72",
     "@ai-sdk/anthropic": "^3.0.58",
+    "@ai-sdk/azure": "^3.0.42",
     "@ai-sdk/google-vertex": "^4.0.47",
     "@ai-sdk/groq": "^3.0.22",
     "@ai-sdk/openai": "^3.0.41",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -28,7 +28,7 @@
     "@elysiajs/cors": "catalog:",
     "@elysiajs/openapi": "catalog:",
     "@elysiajs/opentelemetry": "catalog:",
-    "@hebo-ai/gateway": "0.8.0-rc3",
+    "@hebo-ai/gateway": "^0.8.0",
     "@hebo/api": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -10,6 +10,7 @@
     "dev": "bun --hot src/index.ts",
     "format": "oxfmt .",
     "lint": "oxlint",
+    "test": "bun test",
     "typecheck": "oxlint --type-aware --type-check",
     "prestart": "bun run build",
     "start": "./dist/server"

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -44,12 +44,15 @@ export const gw = gateway({
       project: secrets.vertexProject,
     }),
     voyage: createProvider("voyage", { authMode: "api-key", apiKey: secrets.voyageApiKey }),
-    anthropic: createProvider("anthropic", { authMode: "api-key", apiKey: secrets.anthropicApiKey }),
+    anthropic: createProvider("anthropic", {
+      authMode: "api-key",
+      apiKey: secrets.anthropicApiKey,
+    }),
     openai: createProvider("openai", { authMode: "api-key", apiKey: secrets.openAiApiKey }),
     azure: createProvider("azure", {
-      authMode: "azure-api-key",
-      apiKey: secrets.azureApiKey,
+      authMode: "resource-api-key",
       resourceName: secrets.azureResourceName,
+      apiKey: secrets.azureApiKey,
     }),
   },
 

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -44,6 +44,10 @@ export const gw = gateway({
     voyage: createProvider("voyage", { apiKey: secrets.voyageApiKey }),
     anthropic: createProvider("anthropic", { apiKey: secrets.anthropicApiKey }),
     openai: createProvider("openai", { apiKey: secrets.openAiApiKey }),
+    azure: createProvider("azure", {
+      apiKey: secrets.azureApiKey,
+      resourceName: secrets.azureResourceName,
+    }),
   },
 
   models: defineModelCatalog(

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -47,7 +47,7 @@ export const gw = gateway({
     anthropic: createProvider("anthropic", { authMode: "api-key", apiKey: secrets.anthropicApiKey }),
     openai: createProvider("openai", { authMode: "api-key", apiKey: secrets.openAiApiKey }),
     azure: createProvider("azure", {
-      authMode: "api-key",
+      authMode: "azure-api-key",
       apiKey: secrets.azureApiKey,
       resourceName: secrets.azureResourceName,
     }),

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -57,34 +57,14 @@ export const gw = gateway({
   },
 
   models: defineModelCatalog(
-    gptOss20b({
-      providers: ["bedrock", "groq", "openai"],
-      ...withTier("openai/gpt-oss-20b"),
-    }),
-    gptOss120b({
-      providers: ["bedrock", "groq", "openai"],
-      ...withTier("openai/gpt-oss-120b"),
-    }),
-    gemini["v3.x"].map((preset) =>
-      preset({ providers: ["vertex"], ...withTier("google/gemini-2.5-pro") }),
-    ),
-    claudeOpus46({
-      providers: ["bedrock", "vertex", "anthropic"],
-      ...withTier("anthropic/claude-opus-4.6"),
-    }),
-    claudeSonnet46({
-      providers: ["bedrock", "vertex", "anthropic"],
-      ...withTier("anthropic/claude-sonnet-4.6"),
-    }),
-    claudeHaiku45({
-      providers: ["bedrock", "vertex", "anthropic"],
-      ...withTier("anthropic/claude-haiku-4.5"),
-    }),
-    nova2MultimodalEmbeddings({
-      providers: ["bedrock"],
-      ...withTier("amazon/nova-2-multimodal-embeddings"),
-    }),
-    voyage35({ providers: ["voyage"], ...withTier("voyage/voyage-3.5") }),
+    gptOss20b(withTier("openai/gpt-oss-20b")),
+    gptOss120b(withTier("openai/gpt-oss-120b")),
+    gemini["v3.x"].map((preset) => preset(withTier("google/gemini-2.5-pro"))),
+    claudeOpus46(withTier("anthropic/claude-opus-4.6")),
+    claudeSonnet46(withTier("anthropic/claude-sonnet-4.6")),
+    claudeHaiku45(withTier("anthropic/claude-haiku-4.5")),
+    nova2MultimodalEmbeddings(withTier("amazon/nova-2-multimodal-embeddings")),
+    voyage35(withTier("voyage/voyage-3.5")),
   ),
 
   hooks: {

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -30,21 +30,24 @@ export const gw = gateway({
   basePath,
 
   providers: {
-    groq: createProvider("groq", { apiKey: secrets.groqApiKey }),
+    groq: createProvider("groq", { authMode: "api-key", apiKey: secrets.groqApiKey }),
     bedrock: createProvider("bedrock", {
+      authMode: "iam-role",
       bedrockRoleArn: secrets.bedrockRoleArn,
       region: secrets.bedrockRegion,
     }),
     vertex: createProvider("vertex", {
+      authMode: "identity-federation",
       serviceAccountEmail: secrets.vertexServiceAccountEmail,
       audience: secrets.vertexAudience,
       location: secrets.vertexLocation,
       project: secrets.vertexProject,
     }),
-    voyage: createProvider("voyage", { apiKey: secrets.voyageApiKey }),
-    anthropic: createProvider("anthropic", { apiKey: secrets.anthropicApiKey }),
-    openai: createProvider("openai", { apiKey: secrets.openAiApiKey }),
+    voyage: createProvider("voyage", { authMode: "api-key", apiKey: secrets.voyageApiKey }),
+    anthropic: createProvider("anthropic", { authMode: "api-key", apiKey: secrets.anthropicApiKey }),
+    openai: createProvider("openai", { authMode: "api-key", apiKey: secrets.openAiApiKey }),
     azure: createProvider("azure", {
+      authMode: "api-key",
       apiKey: secrets.azureApiKey,
       resourceName: secrets.azureResourceName,
     }),

--- a/apps/gateway/src/services/model-resolver.test.ts
+++ b/apps/gateway/src/services/model-resolver.test.ts
@@ -124,12 +124,11 @@ describe("resolveProvider", () => {
         requiresByok: false,
         bedrockProvider: undefined,
       });
-      ctx.providers.bedrock = undefined;
       const result = await resolveProvider(ctx);
       expect(result).toBeUndefined();
     });
 
-    it("prefers bedrock for aliased routes when the resolved model supports it", async () => {
+    it("does not override explicit aliased routing", async () => {
       const ctx = makeCtx({
         modelId: "agent/main/copilot",
         resolvedModelId: "anthropic/claude-opus-4.6",
@@ -138,7 +137,7 @@ describe("resolveProvider", () => {
         customProviderSlug: "anthropic",
       });
       const result = await resolveProvider(ctx);
-      expect(result).toBe(ctx.providers.bedrock);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/apps/gateway/src/services/model-resolver.test.ts
+++ b/apps/gateway/src/services/model-resolver.test.ts
@@ -17,7 +17,10 @@ function makeCtx(overrides: {
   providerConfigsResult?: unknown;
   bedrockProvider?: ProviderV3 | undefined;
 }) {
-  const bedrockProvider = overrides.bedrockProvider ?? ({ id: "bedrock" } as unknown as ProviderV3);
+  const bedrockProvider =
+    "bedrockProvider" in overrides
+      ? overrides.bedrockProvider
+      : ({ id: "bedrock" } as unknown as ProviderV3);
 
   return {
     modelId: overrides.modelId,
@@ -128,7 +131,7 @@ describe("resolveProvider", () => {
       expect(result).toBeUndefined();
     });
 
-    it("does not override explicit aliased routing", async () => {
+    it("returns undefined when a custom provider slug is set but unresolved", async () => {
       const ctx = makeCtx({
         modelId: "agent/main/copilot",
         resolvedModelId: "anthropic/claude-opus-4.6",

--- a/apps/gateway/src/services/model-resolver.test.ts
+++ b/apps/gateway/src/services/model-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import type { ProviderV3 } from "@ai-sdk/provider";
 import { GatewayError } from "@hebo-ai/gateway";
 
 import { resolveProvider } from "./model-resolver";
@@ -7,22 +8,43 @@ import { resolveProvider } from "./model-resolver";
 // Minimal mock for ResolveProviderHookContext
 function makeCtx(overrides: {
   modelId: string;
+  resolvedModelId?: string;
   free?: boolean;
   requiresByok?: boolean;
   customProviderSlug?: string;
   organizationId?: string;
+  modelProviders?: string[];
+  providerConfigsResult?: unknown;
+  bedrockProvider?: ProviderV3 | undefined;
 }) {
+  const bedrockProvider = overrides.bedrockProvider ?? ({ id: "bedrock" } as unknown as ProviderV3);
+
   return {
-    resolvedModelId: overrides.modelId,
+    modelId: overrides.modelId,
+    resolvedModelId: overrides.resolvedModelId ?? overrides.modelId,
+    operation: "chat",
+    request: new Request("https://example.com/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({ model: overrides.modelId, messages: [] }),
+    }),
+    body: { model: overrides.modelId, messages: [] },
+    models: {
+      [overrides.resolvedModelId ?? overrides.modelId]: {
+        providers: overrides.modelProviders ?? ["anthropic", "bedrock", "vertex"],
+      },
+    },
+    providers: {
+      bedrock: bedrockProvider,
+    },
     state: {
-      dbClient: {
+      prismaClient: {
         provider_configs: {
-          getUnredacted: async () => {},
+          getUnredacted: async () => overrides.providerConfigsResult,
         },
       },
       organizationId: overrides.organizationId ?? "org-1",
       modelConfig: {
-        type: overrides.modelId,
+        type: overrides.resolvedModelId ?? overrides.modelId,
         customProviderSlug: overrides.customProviderSlug,
         free: overrides.free,
         requiresByok: overrides.requiresByok,
@@ -69,7 +91,7 @@ describe("resolveProvider", () => {
     it("does not throw for free model without custom provider", async () => {
       const ctx = makeCtx({ modelId: "openai/gpt-oss-20b", free: true, requiresByok: true });
       const result = await resolveProvider(ctx);
-      expect(result).toBeUndefined();
+      expect(result).toBe(ctx.providers.bedrock);
     });
   });
 
@@ -81,7 +103,42 @@ describe("resolveProvider", () => {
         requiresByok: false,
       });
       const result = await resolveProvider(ctx);
+      expect(result).toBe(ctx.providers.bedrock);
+    });
+
+    it("returns undefined when bedrock is not supported by the model", async () => {
+      const ctx = makeCtx({
+        modelId: "google/gemini-3.1-pro-preview",
+        free: false,
+        requiresByok: false,
+        modelProviders: ["vertex"],
+      });
+      const result = await resolveProvider(ctx);
       expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when bedrock is not configured", async () => {
+      const ctx = makeCtx({
+        modelId: "anthropic/claude-opus-4.6",
+        free: false,
+        requiresByok: false,
+        bedrockProvider: undefined,
+      });
+      ctx.providers.bedrock = undefined;
+      const result = await resolveProvider(ctx);
+      expect(result).toBeUndefined();
+    });
+
+    it("prefers bedrock for aliased routes when the resolved model supports it", async () => {
+      const ctx = makeCtx({
+        modelId: "agent/main/copilot",
+        resolvedModelId: "anthropic/claude-opus-4.6",
+        free: false,
+        requiresByok: false,
+        customProviderSlug: "anthropic",
+      });
+      const result = await resolveProvider(ctx);
+      expect(result).toBe(ctx.providers.bedrock);
     });
   });
 });

--- a/apps/gateway/src/services/model-resolver.ts
+++ b/apps/gateway/src/services/model-resolver.ts
@@ -153,18 +153,8 @@ export async function resolveProvider(ctx: ResolveProviderHookContext) {
     );
 
     if (provider) return provider;
-
-    // Org configured a custom provider slug, but no credentials found
-    if (requiresByok && free === false) {
-      throw new GatewayError(
-        "This model requires Bring Your Own Key (BYOK). Configure your provider credentials in the console under Settings → Providers.",
-        402,
-        "BYOK_REQUIRED",
-      );
-    }
   }
 
-  // No custom provider configured — block non-free models when enforcement is on
   if (requiresByok && free === false) {
     throw new GatewayError(
       "This model requires Bring Your Own Key (BYOK). Configure your provider credentials in the console under Settings → Providers.",

--- a/apps/gateway/src/services/model-resolver.ts
+++ b/apps/gateway/src/services/model-resolver.ts
@@ -127,7 +127,7 @@ async function resolveCustomProvider(
 }
 
 export async function resolveProvider(ctx: ResolveProviderHookContext) {
-  const { resolvedModelId: modelId, state } = ctx;
+  const { resolvedModelId: modelId, models, providers, state } = ctx;
 
   const { prismaClient, organizationId } = state as {
     prismaClient: PrismaClient;
@@ -162,8 +162,6 @@ export async function resolveProvider(ctx: ResolveProviderHookContext) {
         "BYOK_REQUIRED",
       );
     }
-
-    return;
   }
 
   // No custom provider configured — block non-free models when enforcement is on
@@ -173,5 +171,10 @@ export async function resolveProvider(ctx: ResolveProviderHookContext) {
       402,
       "BYOK_REQUIRED",
     );
+  }
+
+  // Default to bedrock if supported & available
+  if (providers.bedrock && models[modelId]?.providers.includes("bedrock")) {
+    return providers.bedrock;
   }
 }

--- a/apps/gateway/src/services/model-resolver.ts
+++ b/apps/gateway/src/services/model-resolver.ts
@@ -174,7 +174,7 @@ export async function resolveProvider(ctx: ResolveProviderHookContext) {
   }
 
   // Default to bedrock if supported & available
-  if (providers.bedrock && models[modelId]?.providers.includes("bedrock")) {
+  if (!customProviderSlug && providers.bedrock && models[modelId]?.providers.includes("bedrock")) {
     return providers.bedrock;
   }
 }

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -61,14 +61,22 @@ describe("createProvider", () => {
       });
       expect(provider).toBeUndefined();
     });
+
+    it("returns undefined when authMode is invalid", () => {
+      const provider = createProvider("bedrock", {
+        authMode: "api-key",
+        apiKey: "test-key-123",
+        region: "us-east-1",
+      });
+      expect(provider).toBeUndefined();
+    });
   });
 
   describe("vertex", () => {
-    it("returns undefined when authMode is missing", () => {
+    it("returns undefined when authMode is invalid", () => {
       const provider = createProvider("vertex", {
-        serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
-        audience:
-          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+        authMode: "api-key",
+        apiKey: "test-key-123",
         location: "us-central1",
         project: "my-project",
       });

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -64,7 +64,7 @@ describe("createProvider", () => {
   });
 
   describe("vertex", () => {
-    it("falls back to identity-federation path when authMode is not present", () => {
+    it("returns undefined when authMode is missing", () => {
       const provider = createProvider("vertex", {
         serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
         audience:
@@ -72,7 +72,7 @@ describe("createProvider", () => {
         location: "us-central1",
         project: "my-project",
       });
-      expect(provider).toBeDefined();
+      expect(provider).toBeUndefined();
     });
 
     it("returns undefined when location is missing", () => {

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -77,15 +77,16 @@ describe("createProvider", () => {
 
   describe("azure", () => {
     it("returns undefined when apiKey is missing", () => {
-      expect(createProvider("azure", { apiKey: "", resourceName: "my-resource" })).toBeUndefined();
+      expect(createProvider("azure", { authMode: "api-key", apiKey: "", resourceName: "my-resource" })).toBeUndefined();
     });
 
     it("returns undefined when resourceName is missing", () => {
-      expect(createProvider("azure", { apiKey: "key123", resourceName: "" })).toBeUndefined();
+      expect(createProvider("azure", { authMode: "api-key", apiKey: "key123", resourceName: "" })).toBeUndefined();
     });
 
     it("returns a provider for valid Azure config", () => {
       const provider = createProvider("azure", {
+        authMode: "api-key",
         apiKey: "key123",
         resourceName: "my-resource",
       });
@@ -94,6 +95,7 @@ describe("createProvider", () => {
 
     it("returns a provider with optional apiVersion", () => {
       const provider = createProvider("azure", {
+        authMode: "api-key",
         apiKey: "key123",
         resourceName: "my-resource",
         apiVersion: "2024-02-01",
@@ -105,11 +107,11 @@ describe("createProvider", () => {
   describe("api key providers", () => {
     for (const slug of ["anthropic", "openai", "groq", "voyage"] as const) {
       it(`returns undefined for ${slug} when apiKey is missing`, () => {
-        expect(createProvider(slug, { apiKey: "" })).toBeUndefined();
+        expect(createProvider(slug, { authMode: "api-key", apiKey: "" })).toBeUndefined();
       });
 
       it(`returns a provider for ${slug} with valid apiKey`, () => {
-        const provider = createProvider(slug, { apiKey: "test-key-123" });
+        const provider = createProvider(slug, { authMode: "api-key", apiKey: "test-key-123" });
         expect(provider).toBeDefined();
       });
     }

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -54,12 +54,12 @@ describe("createProvider", () => {
       expect(provider).toBeDefined();
     });
 
-    it("falls back to IAM role path when authMode is not present", () => {
+    it("returns undefined when authMode is missing", () => {
       const provider = createProvider("bedrock", {
         bedrockRoleArn: "arn:aws:iam::123456789012:role/test-role",
         region: "us-east-1",
       });
-      expect(provider).toBeDefined();
+      expect(provider).toBeUndefined();
     });
   });
 
@@ -118,6 +118,17 @@ describe("createProvider", () => {
         project: "my-project",
       });
       expect(provider).toBeDefined();
+    });
+
+    it("returns undefined when authMode is missing", () => {
+      const provider = createProvider("vertex", {
+        serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
+        audience:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+        location: "us-central1",
+        project: "my-project",
+      });
+      expect(provider).toBeUndefined();
     });
   });
 

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -95,15 +95,6 @@ describe("createProvider", () => {
       expect(provider).toBeDefined();
     });
 
-    it("returns a provider with optional apiVersion", () => {
-      const provider = createProvider("azure", {
-        authMode: "azure-api-key",
-        apiKey: "key123",
-        resourceName: "my-resource",
-        apiVersion: "2024-02-01",
-      });
-      expect(provider).toBeDefined();
-    });
   });
 
   describe("api key providers", () => {

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -22,12 +22,12 @@ describe("createProvider", () => {
     });
 
     it("returns undefined when static credentials are incomplete", () => {
-      expect(createProvider("bedrock", { authMode: "static", accessKeyId: "AKIA1234", secretAccessKey: "", region: "us-east-1" })).toBeUndefined();
+      expect(createProvider("bedrock", { authMode: "access-key", accessKeyId: "AKIA1234", secretAccessKey: "", region: "us-east-1" })).toBeUndefined();
     });
 
-    it("returns a provider for valid static credentials", () => {
+    it("returns a provider for valid access-key credentials", () => {
       const provider = createProvider("bedrock", {
-        authMode: "static",
+        authMode: "access-key",
         accessKeyId: "AKIA1234567890ABCDEF",
         secretAccessKey: "secretkey123",
         region: "us-east-1",
@@ -46,12 +46,12 @@ describe("createProvider", () => {
 
   describe("vertex", () => {
     it("returns undefined when location is missing", () => {
-      expect(createProvider("vertex", { authMode: "wif", serviceAccountEmail: "sa@proj.iam.gserviceaccount.com", audience: "aud", location: "", project: "proj" })).toBeUndefined();
+      expect(createProvider("vertex", { authMode: "identity-federation", serviceAccountEmail: "sa@proj.iam.gserviceaccount.com", audience: "aud", location: "", project: "proj" })).toBeUndefined();
     });
 
-    it("returns a provider for valid WIF config", () => {
+    it("returns a provider for valid identity-federation config", () => {
       const provider = createProvider("vertex", {
-        authMode: "wif",
+        authMode: "identity-federation",
         serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
         audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
         location: "us-central1",

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -60,14 +60,16 @@ describe("createProvider", () => {
       expect(provider).toBeDefined();
     });
 
-    it("returns undefined when service account key is missing", () => {
-      expect(createProvider("vertex", { authMode: "service-account", serviceAccountKey: "", location: "us-central1", project: "proj" })).toBeUndefined();
+    it("returns undefined when service account credentials are missing", () => {
+      expect(createProvider("vertex", { authMode: "service-account", clientEmail: "", privateKey: "key", location: "us-central1", project: "proj" })).toBeUndefined();
+      expect(createProvider("vertex", { authMode: "service-account", clientEmail: "sa@test.iam.gserviceaccount.com", privateKey: "", location: "us-central1", project: "proj" })).toBeUndefined();
     });
 
     it("returns a provider for valid service account config", () => {
       const provider = createProvider("vertex", {
         authMode: "service-account",
-        serviceAccountKey: JSON.stringify({ type: "service_account", project_id: "test", private_key_id: "key1", private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n", client_email: "sa@test.iam.gserviceaccount.com", client_id: "123" }),
+        clientEmail: "sa@test.iam.gserviceaccount.com",
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
         location: "us-central1",
         project: "my-project",
       });

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -64,6 +64,17 @@ describe("createProvider", () => {
   });
 
   describe("vertex", () => {
+    it("falls back to identity-federation path when authMode is not present", () => {
+      const provider = createProvider("vertex", {
+        serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
+        audience:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+        location: "us-central1",
+        project: "my-project",
+      });
+      expect(provider).toBeDefined();
+    });
+
     it("returns undefined when location is missing", () => {
       expect(
         createProvider("vertex", {

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -5,11 +5,23 @@ import { createProvider } from "./provider-factory";
 describe("createProvider", () => {
   describe("bedrock", () => {
     it("returns undefined when region is missing", () => {
-      expect(createProvider("bedrock", { authMode: "iam-role", bedrockRoleArn: "arn:aws:iam::123:role/test", region: "" })).toBeUndefined();
+      expect(
+        createProvider("bedrock", {
+          authMode: "iam-role",
+          bedrockRoleArn: "arn:aws:iam::123:role/test",
+          region: "",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns undefined when IAM role ARN is missing", () => {
-      expect(createProvider("bedrock", { authMode: "iam-role", bedrockRoleArn: "", region: "us-east-1" })).toBeUndefined();
+      expect(
+        createProvider("bedrock", {
+          authMode: "iam-role",
+          bedrockRoleArn: "",
+          region: "us-east-1",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns a provider for valid IAM role config", () => {
@@ -22,7 +34,14 @@ describe("createProvider", () => {
     });
 
     it("returns undefined when static credentials are incomplete", () => {
-      expect(createProvider("bedrock", { authMode: "access-key", accessKeyId: "AKIA1234", secretAccessKey: "", region: "us-east-1" })).toBeUndefined();
+      expect(
+        createProvider("bedrock", {
+          authMode: "access-key",
+          accessKeyId: "AKIA1234",
+          secretAccessKey: "",
+          region: "us-east-1",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns a provider for valid access-key credentials", () => {
@@ -46,14 +65,23 @@ describe("createProvider", () => {
 
   describe("vertex", () => {
     it("returns undefined when location is missing", () => {
-      expect(createProvider("vertex", { authMode: "identity-federation", serviceAccountEmail: "sa@proj.iam.gserviceaccount.com", audience: "aud", location: "", project: "proj" })).toBeUndefined();
+      expect(
+        createProvider("vertex", {
+          authMode: "identity-federation",
+          serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
+          audience: "aud",
+          location: "",
+          project: "proj",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns a provider for valid identity-federation config", () => {
       const provider = createProvider("vertex", {
         authMode: "identity-federation",
         serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
-        audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+        audience:
+          "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
         location: "us-central1",
         project: "my-project",
       });
@@ -61,8 +89,24 @@ describe("createProvider", () => {
     });
 
     it("returns undefined when service account credentials are missing", () => {
-      expect(createProvider("vertex", { authMode: "service-account", clientEmail: "", privateKey: "key", location: "us-central1", project: "proj" })).toBeUndefined();
-      expect(createProvider("vertex", { authMode: "service-account", clientEmail: "sa@test.iam.gserviceaccount.com", privateKey: "", location: "us-central1", project: "proj" })).toBeUndefined();
+      expect(
+        createProvider("vertex", {
+          authMode: "service-account",
+          clientEmail: "",
+          privateKey: "key",
+          location: "us-central1",
+          project: "proj",
+        }),
+      ).toBeUndefined();
+      expect(
+        createProvider("vertex", {
+          authMode: "service-account",
+          clientEmail: "sa@test.iam.gserviceaccount.com",
+          privateKey: "",
+          location: "us-central1",
+          project: "proj",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns a provider for valid service account config", () => {
@@ -79,22 +123,33 @@ describe("createProvider", () => {
 
   describe("azure", () => {
     it("returns undefined when apiKey is missing", () => {
-      expect(createProvider("azure", { authMode: "azure-api-key", apiKey: "", resourceName: "my-resource" })).toBeUndefined();
+      expect(
+        createProvider("azure", {
+          authMode: "resource-api-key",
+          apiKey: "",
+          resourceName: "my-resource",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns undefined when resourceName is missing", () => {
-      expect(createProvider("azure", { authMode: "azure-api-key", apiKey: "key123", resourceName: "" })).toBeUndefined();
+      expect(
+        createProvider("azure", {
+          authMode: "resource-api-key",
+          apiKey: "key123",
+          resourceName: "",
+        }),
+      ).toBeUndefined();
     });
 
     it("returns a provider for valid Azure config", () => {
       const provider = createProvider("azure", {
-        authMode: "azure-api-key",
+        authMode: "resource-api-key",
         apiKey: "key123",
         resourceName: "my-resource",
       });
       expect(provider).toBeDefined();
     });
-
   });
 
   describe("api key providers", () => {

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+
+import { createProvider } from "./provider-factory";
+
+describe("createProvider", () => {
+  describe("bedrock", () => {
+    it("returns undefined when region is missing", () => {
+      expect(createProvider("bedrock", { authMode: "iam-role", bedrockRoleArn: "arn:aws:iam::123:role/test", region: "" })).toBeUndefined();
+    });
+
+    it("returns undefined when IAM role ARN is missing", () => {
+      expect(createProvider("bedrock", { authMode: "iam-role", bedrockRoleArn: "", region: "us-east-1" })).toBeUndefined();
+    });
+
+    it("returns a provider for valid IAM role config", () => {
+      const provider = createProvider("bedrock", {
+        authMode: "iam-role",
+        bedrockRoleArn: "arn:aws:iam::123456789012:role/test-role",
+        region: "us-east-1",
+      });
+      expect(provider).toBeDefined();
+    });
+
+    it("returns undefined when static credentials are incomplete", () => {
+      expect(createProvider("bedrock", { authMode: "static", accessKeyId: "AKIA1234", secretAccessKey: "", region: "us-east-1" })).toBeUndefined();
+    });
+
+    it("returns a provider for valid static credentials", () => {
+      const provider = createProvider("bedrock", {
+        authMode: "static",
+        accessKeyId: "AKIA1234567890ABCDEF",
+        secretAccessKey: "secretkey123",
+        region: "us-east-1",
+      });
+      expect(provider).toBeDefined();
+    });
+
+    it("falls back to IAM role path when authMode is not present", () => {
+      const provider = createProvider("bedrock", {
+        bedrockRoleArn: "arn:aws:iam::123456789012:role/test-role",
+        region: "us-east-1",
+      });
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe("vertex", () => {
+    it("returns undefined when location is missing", () => {
+      expect(createProvider("vertex", { authMode: "wif", serviceAccountEmail: "sa@proj.iam.gserviceaccount.com", audience: "aud", location: "", project: "proj" })).toBeUndefined();
+    });
+
+    it("returns a provider for valid WIF config", () => {
+      const provider = createProvider("vertex", {
+        authMode: "wif",
+        serviceAccountEmail: "sa@proj.iam.gserviceaccount.com",
+        audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/aws",
+        location: "us-central1",
+        project: "my-project",
+      });
+      expect(provider).toBeDefined();
+    });
+
+    it("returns undefined when service account key is missing", () => {
+      expect(createProvider("vertex", { authMode: "service-account", serviceAccountKey: "", location: "us-central1", project: "proj" })).toBeUndefined();
+    });
+
+    it("returns a provider for valid service account config", () => {
+      const provider = createProvider("vertex", {
+        authMode: "service-account",
+        serviceAccountKey: JSON.stringify({ type: "service_account", project_id: "test", private_key_id: "key1", private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n", client_email: "sa@test.iam.gserviceaccount.com", client_id: "123" }),
+        location: "us-central1",
+        project: "my-project",
+      });
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe("azure", () => {
+    it("returns undefined when apiKey is missing", () => {
+      expect(createProvider("azure", { apiKey: "", resourceName: "my-resource" })).toBeUndefined();
+    });
+
+    it("returns undefined when resourceName is missing", () => {
+      expect(createProvider("azure", { apiKey: "key123", resourceName: "" })).toBeUndefined();
+    });
+
+    it("returns a provider for valid Azure config", () => {
+      const provider = createProvider("azure", {
+        apiKey: "key123",
+        resourceName: "my-resource",
+      });
+      expect(provider).toBeDefined();
+    });
+
+    it("returns a provider with optional apiVersion", () => {
+      const provider = createProvider("azure", {
+        apiKey: "key123",
+        resourceName: "my-resource",
+        apiVersion: "2024-02-01",
+      });
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe("api key providers", () => {
+    for (const slug of ["anthropic", "openai", "groq", "voyage"] as const) {
+      it(`returns undefined for ${slug} when apiKey is missing`, () => {
+        expect(createProvider(slug, { apiKey: "" })).toBeUndefined();
+      });
+
+      it(`returns a provider for ${slug} with valid apiKey`, () => {
+        const provider = createProvider(slug, { apiKey: "test-key-123" });
+        expect(provider).toBeDefined();
+      });
+    }
+  });
+
+  it("throws for unsupported provider", () => {
+    expect(() => createProvider("unknown" as never, {})).toThrow("Unsupported provider: unknown");
+  });
+});

--- a/apps/gateway/src/services/provider-factory.test.ts
+++ b/apps/gateway/src/services/provider-factory.test.ts
@@ -79,16 +79,16 @@ describe("createProvider", () => {
 
   describe("azure", () => {
     it("returns undefined when apiKey is missing", () => {
-      expect(createProvider("azure", { authMode: "api-key", apiKey: "", resourceName: "my-resource" })).toBeUndefined();
+      expect(createProvider("azure", { authMode: "azure-api-key", apiKey: "", resourceName: "my-resource" })).toBeUndefined();
     });
 
     it("returns undefined when resourceName is missing", () => {
-      expect(createProvider("azure", { authMode: "api-key", apiKey: "key123", resourceName: "" })).toBeUndefined();
+      expect(createProvider("azure", { authMode: "azure-api-key", apiKey: "key123", resourceName: "" })).toBeUndefined();
     });
 
     it("returns a provider for valid Azure config", () => {
       const provider = createProvider("azure", {
-        authMode: "api-key",
+        authMode: "azure-api-key",
         apiKey: "key123",
         resourceName: "my-resource",
       });
@@ -97,7 +97,7 @@ describe("createProvider", () => {
 
     it("returns a provider with optional apiVersion", () => {
       const provider = createProvider("azure", {
-        authMode: "api-key",
+        authMode: "azure-api-key",
         apiKey: "key123",
         resourceName: "my-resource",
         apiVersion: "2024-02-01",

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -91,7 +91,7 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       const region = bedrockConfig.region;
       if (!region) return;
 
-      if ("authMode" in bedrockConfig && bedrockConfig.authMode === "static") {
+      if ("authMode" in bedrockConfig && bedrockConfig.authMode === "access-key") {
         const { accessKeyId, secretAccessKey } = bedrockConfig;
         if (!accessKeyId || !secretAccessKey) return;
         return withCanonicalIdsForBedrock(
@@ -145,7 +145,7 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
         );
       }
 
-      // Default: WIF path (cloud deployments)
+      // Default: Identity federation path (cloud deployments)
       const serviceAccountEmail =
         "serviceAccountEmail" in vertexConfig ? vertexConfig.serviceAccountEmail : undefined;
       const audience = "audience" in vertexConfig ? vertexConfig.audience : undefined;

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -176,11 +176,9 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       return withCanonicalIdsForOpenAI(createOpenAI({ apiKey }));
     }
     case "azure": {
-      const { apiKey, resourceName, apiVersion } = config as AzureProviderConfig;
+      const { apiKey, resourceName } = config as AzureProviderConfig;
       if (!apiKey || !resourceName) return;
-      return withCanonicalIdsForOpenAI(
-        createAzure({ apiKey, resourceName, apiVersion: apiVersion?.trim() || undefined }),
-      );
+      return withCanonicalIdsForOpenAI(createAzure({ apiKey, resourceName }));
     }
     default: {
       throw new Error(`Unsupported provider: ${slug}`);

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -85,6 +85,8 @@ export async function loadProviderSecrets() {
 }
 
 export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 | undefined {
+  if (config == null || typeof config !== "object") return;
+
   switch (slug) {
     case "bedrock": {
       const bedrockConfig = config as BedrockProviderConfig;

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -120,6 +120,8 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
             },
           );
         }
+        default:
+          return;
       }
     }
     case "groq": {
@@ -161,6 +163,8 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
             }),
           );
         }
+        default:
+          return;
       }
     }
     case "voyage": {

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -130,13 +130,12 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       if (!location || !project) return;
 
       if ("authMode" in vertexConfig && vertexConfig.authMode === "service-account") {
-        const { serviceAccountKey } = vertexConfig;
-        if (!serviceAccountKey) return;
-        const credentials = JSON.parse(serviceAccountKey);
+        const { clientEmail, privateKey } = vertexConfig;
+        if (!clientEmail || !privateKey) return;
         return withCanonicalIdsForVertex(
           createVertex({
             googleAuthOptions: {
-              credentials,
+              credentials: { client_email: clientEmail, private_key: privateKey },
               scopes: ["https://www.googleapis.com/auth/cloud-platform"],
             },
             location,

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -179,7 +179,7 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       const { apiKey, resourceName, apiVersion } = config as AzureProviderConfig;
       if (!apiKey || !resourceName) return;
       return withCanonicalIdsForOpenAI(
-        createAzure({ apiKey, resourceName, apiVersion }),
+        createAzure({ apiKey, resourceName, apiVersion: apiVersion?.trim() || undefined }),
       );
     }
     default: {

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -1,5 +1,6 @@
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { createAzure } from "@ai-sdk/azure";
 import { createVertex } from "@ai-sdk/google-vertex";
 import { createGroq } from "@ai-sdk/groq";
 import { createOpenAI } from "@ai-sdk/openai";
@@ -17,6 +18,7 @@ import { getSecret } from "@hebo/shared-api/utils/secrets";
 
 import type {
   ApiKeyProviderConfig,
+  AzureProviderConfig,
   BedrockProviderConfig,
   ProviderSlug,
   VertexProviderConfig,
@@ -36,6 +38,8 @@ export async function loadProviderSecrets() {
     vertexProject,
     anthropicApiKey,
     openAiApiKey,
+    azureApiKey,
+    azureResourceName,
     enforceByok,
     freeModelIdsRaw,
   ] = await Promise.all([
@@ -49,6 +53,8 @@ export async function loadProviderSecrets() {
     getSecret("VertexProject"),
     getSecret("AnthropicApiKey"),
     getSecret("OpenAiApiKey"),
+    getSecret("AzureOpenAiApiKey"),
+    getSecret("AzureOpenAiResourceName"),
     getSecret("EnforceByok").then((v) => v === "true"),
     getSecret("FreeModelIds"),
   ]);
@@ -71,6 +77,8 @@ export async function loadProviderSecrets() {
     vertexProject,
     anthropicApiKey,
     openAiApiKey,
+    azureApiKey,
+    azureResourceName,
     enforceByok,
     freeModelIds,
   };
@@ -79,8 +87,22 @@ export async function loadProviderSecrets() {
 export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 | undefined {
   switch (slug) {
     case "bedrock": {
-      const { bedrockRoleArn, region } = config as BedrockProviderConfig;
-      if (!bedrockRoleArn || !region) return;
+      const bedrockConfig = config as BedrockProviderConfig;
+      const region = bedrockConfig.region;
+      if (!region) return;
+
+      if ("authMode" in bedrockConfig && bedrockConfig.authMode === "static") {
+        const { accessKeyId, secretAccessKey } = bedrockConfig;
+        if (!accessKeyId || !secretAccessKey) return;
+        return withCanonicalIdsForBedrock(
+          createAmazonBedrock({ region, accessKeyId, secretAccessKey }),
+        );
+      }
+
+      // Default: IAM role path (cloud deployments)
+      const bedrockRoleArn =
+        "bedrockRoleArn" in bedrockConfig ? bedrockConfig.bedrockRoleArn : undefined;
+      if (!bedrockRoleArn) return;
       return withCanonicalIdsForBedrock(
         createAmazonBedrock({
           region,
@@ -103,8 +125,31 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       return withCanonicalIdsForGroq(createGroq({ apiKey }));
     }
     case "vertex": {
-      const { serviceAccountEmail, audience, location, project } = config as VertexProviderConfig;
-      if (!serviceAccountEmail || !audience || !location || !project) return;
+      const vertexConfig = config as VertexProviderConfig;
+      const { location, project } = vertexConfig;
+      if (!location || !project) return;
+
+      if ("authMode" in vertexConfig && vertexConfig.authMode === "service-account") {
+        const { serviceAccountKey } = vertexConfig;
+        if (!serviceAccountKey) return;
+        const credentials = JSON.parse(serviceAccountKey);
+        return withCanonicalIdsForVertex(
+          createVertex({
+            googleAuthOptions: {
+              credentials,
+              scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+            },
+            location,
+            project,
+          }),
+        );
+      }
+
+      // Default: WIF path (cloud deployments)
+      const serviceAccountEmail =
+        "serviceAccountEmail" in vertexConfig ? vertexConfig.serviceAccountEmail : undefined;
+      const audience = "audience" in vertexConfig ? vertexConfig.audience : undefined;
+      if (!serviceAccountEmail || !audience) return;
       return withCanonicalIdsForVertex(
         createVertex({
           googleAuthOptions: {
@@ -130,6 +175,13 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       const { apiKey } = config as ApiKeyProviderConfig;
       if (!apiKey) return;
       return withCanonicalIdsForOpenAI(createOpenAI({ apiKey }));
+    }
+    case "azure": {
+      const { apiKey, resourceName, apiVersion } = config as AzureProviderConfig;
+      if (!apiKey || !resourceName) return;
+      return withCanonicalIdsForOpenAI(
+        createAzure({ apiKey, resourceName, apiVersion }),
+      );
     }
     default: {
       throw new Error(`Unsupported provider: ${slug}`);

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -93,33 +93,34 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       const region = bedrockConfig.region;
       if (!region) return;
 
-      if ("authMode" in bedrockConfig && bedrockConfig.authMode === "access-key") {
-        const { accessKeyId, secretAccessKey } = bedrockConfig;
-        if (!accessKeyId || !secretAccessKey) return;
-        return withCanonicalIdsForBedrock(
-          createAmazonBedrock({ region, accessKeyId, secretAccessKey }),
-        );
+      switch (bedrockConfig.authMode) {
+        case "access-key": {
+          const { accessKeyId, secretAccessKey } = bedrockConfig;
+          if (!accessKeyId || !secretAccessKey) return;
+          return withCanonicalIdsForBedrock(
+            createAmazonBedrock({ region, accessKeyId, secretAccessKey }),
+          );
+        }
+        case "iam-role": {
+          const { bedrockRoleArn } = bedrockConfig;
+          if (!bedrockRoleArn) return;
+          return withCanonicalIdsForBedrock(
+            createAmazonBedrock({
+              region,
+              credentialProvider: fromTemporaryCredentials({
+                params: { RoleArn: bedrockRoleArn },
+                masterCredentials: fromContainerMetadata(),
+                clientConfig: { region },
+              }),
+            }),
+            {
+              inferenceProfile: {
+                arn: { accountId: bedrockRoleArn.split(":")[4], region },
+              },
+            },
+          );
+        }
       }
-
-      // Default: IAM role path (cloud deployments)
-      const bedrockRoleArn =
-        "bedrockRoleArn" in bedrockConfig ? bedrockConfig.bedrockRoleArn : undefined;
-      if (!bedrockRoleArn) return;
-      return withCanonicalIdsForBedrock(
-        createAmazonBedrock({
-          region,
-          credentialProvider: fromTemporaryCredentials({
-            params: { RoleArn: bedrockRoleArn },
-            masterCredentials: fromContainerMetadata(),
-            clientConfig: { region },
-          }),
-        }),
-        {
-          inferenceProfile: {
-            arn: { accountId: bedrockRoleArn.split(":")[4], region },
-          },
-        },
-      );
     }
     case "groq": {
       const { apiKey } = config as ApiKeyProviderConfig;
@@ -131,36 +132,36 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
       const { location, project } = vertexConfig;
       if (!location || !project) return;
 
-      if ("authMode" in vertexConfig && vertexConfig.authMode === "service-account") {
-        const { clientEmail, privateKey } = vertexConfig;
-        if (!clientEmail || !privateKey) return;
-        return withCanonicalIdsForVertex(
-          createVertex({
-            googleAuthOptions: {
-              credentials: { client_email: clientEmail, private_key: privateKey },
-              scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-            },
-            location,
-            project,
-          }),
-        );
+      switch (vertexConfig.authMode) {
+        case "service-account": {
+          const { clientEmail, privateKey } = vertexConfig;
+          if (!clientEmail || !privateKey) return;
+          return withCanonicalIdsForVertex(
+            createVertex({
+              googleAuthOptions: {
+                credentials: { client_email: clientEmail, private_key: privateKey },
+                scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+              },
+              location,
+              project,
+            }),
+          );
+        }
+        case "identity-federation": {
+          const { serviceAccountEmail, audience } = vertexConfig;
+          if (!serviceAccountEmail || !audience) return;
+          return withCanonicalIdsForVertex(
+            createVertex({
+              googleAuthOptions: {
+                credentials: buildWifOptions(audience, serviceAccountEmail),
+                scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+              },
+              location,
+              project,
+            }),
+          );
+        }
       }
-
-      // Default: Identity federation path (cloud deployments)
-      const serviceAccountEmail =
-        "serviceAccountEmail" in vertexConfig ? vertexConfig.serviceAccountEmail : undefined;
-      const audience = "audience" in vertexConfig ? vertexConfig.audience : undefined;
-      if (!serviceAccountEmail || !audience) return;
-      return withCanonicalIdsForVertex(
-        createVertex({
-          googleAuthOptions: {
-            credentials: buildWifOptions(audience, serviceAccountEmail),
-            scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-          },
-          location,
-          project,
-        }),
-      );
     }
     case "voyage": {
       const { apiKey } = config as ApiKeyProviderConfig;

--- a/apps/gateway/src/services/provider-factory.ts
+++ b/apps/gateway/src/services/provider-factory.ts
@@ -180,7 +180,7 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
     case "azure": {
       const { apiKey, resourceName } = config as AzureProviderConfig;
       if (!apiKey || !resourceName) return;
-      return withCanonicalIdsForOpenAI(createAzure({ apiKey, resourceName }));
+      return createAzure({ apiKey, resourceName });
     }
     default: {
       throw new Error(`Unsupported provider: ${slug}`);

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.72",
         "@ai-sdk/anthropic": "^3.0.58",
+        "@ai-sdk/azure": "^3.0.42",
         "@ai-sdk/google-vertex": "^4.0.47",
         "@ai-sdk/groq": "^3.0.22",
         "@ai-sdk/openai": "^3.0.41",
@@ -290,6 +291,8 @@
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.77", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.58", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PKLqycbq4NHCasZ0454HZh58thDGsqEKnpkXYr+Ym4Y4YFL3vhLUwhvvZeuOfawVdmMijQfRiKeAZhd2XtTkOg=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q=="],
+
+    "@ai-sdk/azure": ["@ai-sdk/azure@3.0.42", "", { "dependencies": { "@ai-sdk/openai": "3.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BGg0e3GEI7KHkwUv7d5f9rXzDlTiWhQ4xzVakdHLV/OP24jvXes5X7fI3QZ0rbKBop6URq0yaxomBfwEqqRlzw=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.66", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -128,7 +128,7 @@
         "@elysiajs/cors": "catalog:",
         "@elysiajs/openapi": "catalog:",
         "@elysiajs/opentelemetry": "catalog:",
-        "@hebo-ai/gateway": "0.8.0-rc3",
+        "@hebo-ai/gateway": "^0.8.0",
         "@hebo/api": "workspace:*",
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
@@ -560,7 +560,7 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.8.0-rc3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "lru-cache": "^11.2.6", "uuid": "^13.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google": "^3.0.43", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@libsql/client": "^0.14.0", "@opentelemetry/api": "^1.9.0", "better-sqlite3": "^11.0.0", "mysql2": "^3.11.0", "pg": "^8.13.0", "postgres": "^3.4.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider"] }, "sha512-tdoo5ArMz6Czn21MjfNkXTpI1BBa2TlrVhhKGbs7WAYqaxXDi7etz0b0IDXfJP+lLr80mk9PzCiYnNuw1PHtqg=="],
+    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.8.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.8", "ai": "^6.0.116", "lru-cache": "^11.2.6", "uuid": "^13.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.77", "@ai-sdk/anthropic": "^3.0.58", "@ai-sdk/cohere": "^3.0.25", "@ai-sdk/google": "^3.0.43", "@ai-sdk/google-vertex": "^4.0.80", "@ai-sdk/groq": "^3.0.29", "@ai-sdk/openai": "^3.0.41", "@libsql/client": "^0.14.0", "@opentelemetry/api": "^1.9.0", "better-sqlite3": "^11.0.0", "mysql2": "^3.11.0", "pg": "^8.13.0", "postgres": "^3.4.0", "typescript": "^5.9.3", "voyage-ai-provider": "^3.0.0" }, "optionalPeers": ["@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/google", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/openai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider"] }, "sha512-Ms6oIvFV0qI4bOPHPYq4sqSK/4OktV0zIufi0HXHmSz5nf+tujQW8YBGpMcwu2OtCuJ1BIbV21itQKOLdVoEuw=="],
 
     "@hebo/aikit-ui": ["@hebo/aikit-ui@workspace:packages/aikit-ui"],
 

--- a/packages/shared-ui/src/_shadcn/ui/textarea.tsx
+++ b/packages/shared-ui/src/_shadcn/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "../../lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1.5 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/packages/shared-ui/src/components/Textarea.tsx
+++ b/packages/shared-ui/src/components/Textarea.tsx
@@ -1,0 +1,13 @@
+import { Textarea as ShadCnTextarea } from "../_shadcn/ui/textarea";
+import { cn } from "../lib/utils";
+
+interface TextareaProps extends React.ComponentProps<"textarea"> {}
+
+export function Textarea({ className, ...props }: TextareaProps) {
+  return (
+    <ShadCnTextarea
+      className={cn("bg-background text-sm", className)}
+      {...props}
+    />
+  );
+}

--- a/packages/shared-ui/src/components/Textarea.tsx
+++ b/packages/shared-ui/src/components/Textarea.tsx
@@ -4,10 +4,5 @@ import { cn } from "../lib/utils";
 interface TextareaProps extends React.ComponentProps<"textarea"> {}
 
 export function Textarea({ className, ...props }: TextareaProps) {
-  return (
-    <ShadCnTextarea
-      className={cn("bg-background text-sm", className)}
-      {...props}
-    />
-  );
+  return <ShadCnTextarea className={cn("bg-background text-sm", className)} {...props} />;
 }


### PR DESCRIPTION
Adds `authMode` discriminated union for Bedrock (iam-role | static) and Vertex (wif | service-account) to support self-hosted deployments. Adds Azure OpenAI as a new provider. Console UI uses tabs to switch auth modes.

Closes #300

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure provider (resource API-key + resource selection), multiple auth modes for Bedrock and Vertex, and auth-mode tabs in provider UI; provider icons now show Microsoft for Azure
  * Added a reusable Textarea component for multiline inputs

* **Tests**
  * Added provider-factory tests covering new providers and auth modes

* **Style**
  * Improved label formatting for hyphenated keys

* **Chores**
  * Gateway configuration updated to register Azure and adopt authMode-aware provider definitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->