### PR TITLE
fix(api): filter soft deleted records for nested operations

### DIFF
--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -14,17 +14,30 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
   if (!organizationId || !userId) {
     throw new Error("Organization ID and User ID are required");
   }
+
+  const tenantFilters = { deleted_at: dbNull, organization_id: organizationId };
+
   return prisma.$extends({
     query: {
       $allModels: {
         $allOperations({ args, query, operation }) {
           if (operation !== "create") {
-            const a = args as { where?: Record<string, unknown> };
-            a.where = {
-              ...a.where,
-              deleted_at: dbNull,
-              organization_id: organizationId,
+            const a = args as {
+              where?: Record<string, unknown>;
+              include?: Record<string, unknown>;
             };
+            a.where = { ...a.where, ...tenantFilters };
+
+            // Prisma's $allOperations hook does not intercept nested relation
+            // queries resolved via `include`. We inject tenant + soft-delete
+            // filters into `include` entries so related rows are filtered too.
+            if (a.include) {
+              for (const [key, value] of Object.entries(a.include)) {
+                if (value === true) {
+                  a.include[key] = { where: tenantFilters };
+                }
+              }
+            }
           }
 
           return query(args);

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -22,8 +22,10 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
       $allModels: {
         $allOperations({ args, query, operation }) {
           if (!["create", "createMany", "createManyAndReturn"].includes(operation)) {
+            // oxlint-disable no-unsafe-member-access, no-unsafe-assignment
             const queryArgs = args as any;
             queryArgs.where = { ...queryArgs.where, ...tenantFilters };
+            // oxlint-enable no-unsafe-member-access, no-unsafe-assignment
 
             // Prisma's $allOperations hook does not intercept nested relation
             // queries resolved via `include`. We inject tenant + soft-delete

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -31,10 +31,10 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
             // filters into `include` entries so related rows are filtered too.
             if (queryArgs.include) {
               for (const [key, value] of Object.entries(queryArgs.include)) {
-                if (value === true) {
-                  queryArgs.include[key] = { where: tenantFilters };
-                } else if (typeof value === "object" && value !== null) {
-                  (value as any).where = { ...(value as any).where, ...tenantFilters };
+                if (value) {
+                  const opts = value === true ? {} : (value as any);
+                  opts.where = { ...opts.where, ...tenantFilters };
+                  queryArgs.include[key] = opts;
                 }
               }
             }

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -22,10 +22,9 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
       $allModels: {
         $allOperations({ args, query, operation }) {
           if (!["create", "createMany", "createManyAndReturn"].includes(operation)) {
-            // oxlint-disable no-unsafe-member-access, no-unsafe-assignment
+            // oxlint-disable no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument
             const queryArgs = args as any;
             queryArgs.where = { ...queryArgs.where, ...tenantFilters };
-            // oxlint-enable no-unsafe-member-access, no-unsafe-assignment
 
             // Prisma's $allOperations hook does not intercept nested relation
             // queries resolved via `include`. We inject tenant + soft-delete
@@ -37,6 +36,7 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
                 }
               }
             }
+            // oxlint-enable no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument
           }
           return query(args);
         },

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -23,7 +23,10 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
         $allOperations({ args, query, operation }) {
           if (!["create", "createMany", "createManyAndReturn"].includes(operation)) {
             // oxlint-disable no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument
-            const queryArgs = args as any;
+            const queryArgs = args as {
+              where?: Record<string, unknown>;
+              include?: Record<string, unknown>;
+            };
             queryArgs.where = { ...queryArgs.where, ...tenantFilters };
 
             // Prisma's $allOperations hook does not intercept nested relation

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -22,19 +22,19 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
       $allModels: {
         $allOperations({ args, query, operation }) {
           if (operation !== "create") {
-            const a = args as {
+            const queryArgs = args as {
               where?: Record<string, unknown>;
               include?: Record<string, unknown>;
             };
-            a.where = { ...a.where, ...tenantFilters };
+            queryArgs.where = { ...queryArgs.where, ...tenantFilters };
 
             // Prisma's $allOperations hook does not intercept nested relation
             // queries resolved via `include`. We inject tenant + soft-delete
             // filters into `include` entries so related rows are filtered too.
-            if (a.include) {
-              for (const [key, value] of Object.entries(a.include)) {
+            if (queryArgs.include) {
+              for (const [key, value] of Object.entries(queryArgs.include)) {
                 if (value === true) {
-                  a.include[key] = { where: tenantFilters };
+                  queryArgs.include[key] = { where: tenantFilters };
                 }
               }
             }

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -33,6 +33,8 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
               for (const [key, value] of Object.entries(queryArgs.include)) {
                 if (value === true) {
                   queryArgs.include[key] = { where: tenantFilters };
+                } else if (typeof value === "object" && value !== null) {
+                  (value as any).where = { ...(value as any).where, ...tenantFilters };
                 }
               }
             }

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -22,7 +22,6 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
       $allModels: {
         $allOperations({ args, query, operation }) {
           if (!["create", "createMany", "createManyAndReturn"].includes(operation)) {
-            // oxlint-disable no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument
             const queryArgs = args as {
               where?: Record<string, unknown>;
               include?: Record<string, unknown>;
@@ -41,7 +40,6 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
                 }
               }
             }
-            // oxlint-enable no-unsafe-member-access, no-unsafe-assignment, no-unsafe-argument
           }
           return query(args);
         },

--- a/apps/api/src/lib/prisma/client.ts
+++ b/apps/api/src/lib/prisma/client.ts
@@ -32,7 +32,7 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
             if (queryArgs.include) {
               for (const [key, value] of Object.entries(queryArgs.include)) {
                 if (value) {
-                  const opts = value === true ? {} : (value as any);
+                  const opts = value === true ? {} : (value as { where?: Record<string, unknown> });
                   opts.where = { ...opts.where, ...tenantFilters };
                   queryArgs.include[key] = opts;
                 }


### PR DESCRIPTION
Fixes: #314

## Problem

Deleting a branch via the UI (or API) soft-deletes the record (`deleted_at` is set), but the branch still appears in the list — even after a full page reload. Attempting to delete it again returns a 404, and navigating to the deleted branch's model configuration page allows actions that fail with "resource not found".

## Root cause

Prisma Client extensions' `query` component [does not intercept nested read/write operations](https://www.prisma.io/docs/orm/prisma-client/client-extensions#usage-with-nested-operations). Our `$allOperations` hook correctly injects `deleted_at: null` and `organization_id` filters into top-level queries, but when the agents endpoint uses `include: { branches: true }`, Prisma resolves the nested relation as a separate internal query that **bypasses the extension hook entirely**.

This means `GET /v1/agents/:slug?branches=true` returns soft-deleted branches, while `GET /v1/agents/:slug/branches` (a top-level query) correctly excludes them.

**Related resources:**
- [Prisma docs: extension limitations for nested operations](https://www.prisma.io/docs/orm/prisma-client/client-extensions#usage-with-nested-operations)
- [prisma/docs#5217 — make it obvious that extensions don't work with nested reads/writes](https://github.com/prisma/docs/issues/5217)
- [Blog post documenting the issue and workarounds](https://matranga.dev/true-soft-deletion-in-prisma-orm/)

## Fix

Inject tenant + soft-delete filters into `include` entries inside the existing `$allOperations` hook, so nested relation queries are filtered too.

## Verified with curl

```
# Create branch
POST /v1/agents/agent-fjp/branches → 201 (created "test-simple")

# Delete branch
DELETE /v1/agents/agent-fjp/branches/test-simple → 204

# Before fix: branch still returned in include
GET /v1/agents/agent-fjp?branches=true → ["main", "test-simple"] ❌

# After fix: branch correctly excluded
GET /v1/agents/agent-fjp?branches=true → ["main"] ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened backend filtering so tenant boundaries and soft-deleted records are consistently enforced, including for related and nested data returned by queries.
  * Related/included records now inherit the same tenant and deletion constraints to improve data isolation and consistency; no visible UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->