### PR TITLE
fix: increase gateway timeouts to support flex service tier

### DIFF
--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -77,6 +77,7 @@ export const gw = gateway({
     resolveProvider,
   },
   logger: createPinoOtelAdapter(getOtelLogger("hebo-gateway", 1)), // trace severity
+  timeouts: { flex: 30 * 60_000 }, // 30 minutes
   telemetry: {
     enabled: true,
     tracer: trace.getTracer("hebo-gateway"),

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -82,7 +82,10 @@ export const gw = gateway({
     resolveProvider,
   },
   logger: createPinoOtelAdapter(getOtelLogger("hebo-gateway", 1)), // trace severity
-  timeouts: { flex: 30 * 60_000 }, // 30 minutes
+  timeouts: {
+    flex: 30 * 60_000, // 30 minutes
+    normal: 5 * 60_000, // 5 minutes
+  },
   telemetry: {
     enabled: true,
     tracer: trace.getTracer("hebo-gateway"),

--- a/apps/gateway/src/gateway-config.ts
+++ b/apps/gateway/src/gateway-config.ts
@@ -14,6 +14,11 @@ import { createPinoOtelAdapter } from "@hebo/shared-api/utils/otel-pino-adapter"
 import { resolveModelId, resolveProvider } from "./services/model-resolver";
 import { createProvider, loadProviderSecrets } from "./services/provider-factory";
 
+// Disable Bun's hardcoded 5-minute fetch timeout (https://github.com/oven-sh/bun/issues/16682)
+const _fetch = globalThis.fetch;
+// @ts-expect-error -- Bun-specific `timeout` option not in standard RequestInit
+globalThis.fetch = ((input, init) => _fetch(input, { ...init, timeout: false })) as typeof fetch;
+
 instrumentFetch("full");
 
 export const basePath = "/v1";

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -44,7 +44,7 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
   },
   transform: {
     loadBalancer: (args) => {
-      args.idleTimeout = 31 * 60; // 31 minutes
+      args.idleTimeout = 30 * 60; // 30 minutes
     },
     listener: (args) => {
       if (args.protocol === "HTTPS") {

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -44,7 +44,7 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
   },
   transform: {
     loadBalancer: (args) => {
-      args.idleTimeout = 300; // 5 minutes
+      args.idleTimeout = 31 * 60; // 31 minutes
     },
     listener: (args) => {
       if (args.protocol === "HTTPS") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased gateway idle connection timeout from 5 minutes to 30 minutes.
  * Added a 30-minute "flex" timeout to gateway settings.
  * Adjusted runtime fetch behavior to use a nonstandard timeout option to align with the new timeout configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->