### PR TITLE
expose reasoning effort in trace detail API

### DIFF
--- a/apps/api/src/modules/traces/service.ts
+++ b/apps/api/src/modules/traces/service.ts
@@ -23,6 +23,8 @@ const OPTIONAL_SPAN_COLUMNS = [
   },
   { column: "span_attributes.gen_ai.usage.reasoning.output_tokens", alias: "reasoning_tokens" },
   { column: "span_attributes.gen_ai.request.reasoning.effort", alias: "reasoning_effort" },
+  { column: "span_attributes.gen_ai.request.reasoning.enabled", alias: "reasoning_enabled" },
+  { column: "span_attributes.gen_ai.request.reasoning.max_tokens", alias: "reasoning_max_tokens" },
 ] as const;
 
 const traceColumnsCache = new LRUCache<
@@ -262,6 +264,8 @@ export async function getSpans(
       cacheReadInputTokens: parseNullableNumber(row.cache_read_input_tokens),
       reasoningTokens: parseNullableNumber(row.reasoning_tokens),
       reasoningEffort: parseString(row.reasoning_effort),
+      reasoningEnabled: row.reasoning_enabled == null ? null : Boolean(row.reasoning_enabled),
+      reasoningMaxTokens: parseNullableNumber(row.reasoning_max_tokens),
       inputMessages: (parseJsonArray(row.input_messages) ?? []) as GenAIInputMessages,
       outputMessages: (parseJsonArray(row.output_messages) ?? []) as GenAIOutputMessages,
       finishReasons: (parseJsonArray(row.finish_reasons) ?? null) as GenAIFinishReasons,

--- a/apps/api/src/modules/traces/service.ts
+++ b/apps/api/src/modules/traces/service.ts
@@ -22,6 +22,7 @@ const OPTIONAL_SPAN_COLUMNS = [
     alias: "cache_read_input_tokens",
   },
   { column: "span_attributes.gen_ai.usage.reasoning.output_tokens", alias: "reasoning_tokens" },
+  { column: "span_attributes.gen_ai.request.reasoning.effort", alias: "reasoning_effort" },
 ] as const;
 
 const traceColumnsCache = new LRUCache<
@@ -260,6 +261,7 @@ export async function getSpans(
       totalTokens: parseNullableNumber(row.total_tokens),
       cacheReadInputTokens: parseNullableNumber(row.cache_read_input_tokens),
       reasoningTokens: parseNullableNumber(row.reasoning_tokens),
+      reasoningEffort: parseString(row.reasoning_effort),
       inputMessages: (parseJsonArray(row.input_messages) ?? []) as GenAIInputMessages,
       outputMessages: (parseJsonArray(row.output_messages) ?? []) as GenAIOutputMessages,
       finishReasons: (parseJsonArray(row.finish_reasons) ?? null) as GenAIFinishReasons,

--- a/apps/api/src/modules/traces/types.ts
+++ b/apps/api/src/modules/traces/types.ts
@@ -117,6 +117,8 @@ export const SpanDetail = t.Object({
   cacheReadInputTokens: t.Nullable(t.Number()),
   reasoningTokens: t.Nullable(t.Number()),
   reasoningEffort: t.String(),
+  reasoningEnabled: t.Nullable(t.Boolean()),
+  reasoningMaxTokens: t.Nullable(t.Number()),
   inputMessages: GenAIInputMessages,
   outputMessages: GenAIOutputMessages,
   finishReasons: GenAIFinishReasons,

--- a/apps/api/src/modules/traces/types.ts
+++ b/apps/api/src/modules/traces/types.ts
@@ -116,6 +116,7 @@ export const SpanDetail = t.Object({
   totalTokens: t.Nullable(t.Number()),
   cacheReadInputTokens: t.Nullable(t.Number()),
   reasoningTokens: t.Nullable(t.Number()),
+  reasoningEffort: t.String(),
   inputMessages: GenAIInputMessages,
   outputMessages: GenAIOutputMessages,
   finishReasons: GenAIFinishReasons,

--- a/apps/console/app/mocks/routes/traces.ts
+++ b/apps/console/app/mocks/routes/traces.ts
@@ -132,6 +132,8 @@ const mockSpanDetails: Record<string, object> = {
     cacheReadInputTokens: null,
     reasoningTokens: null,
     reasoningEffort: "",
+    reasoningEnabled: null,
+    reasoningMaxTokens: null,
     inputMessages: [
       {
         role: "system",
@@ -261,6 +263,8 @@ const mockSpanDetails: Record<string, object> = {
     cacheReadInputTokens: 1024,
     reasoningTokens: 512,
     reasoningEffort: "high",
+    reasoningEnabled: true,
+    reasoningMaxTokens: 4096,
     inputMessages: [
       {
         role: "system",
@@ -326,6 +330,8 @@ const mockSpanDetails: Record<string, object> = {
     cacheReadInputTokens: null,
     reasoningTokens: null,
     reasoningEffort: "",
+    reasoningEnabled: null,
+    reasoningMaxTokens: null,
     inputMessages: [
       {
         role: "user",
@@ -373,6 +379,8 @@ const mockSpanDetails: Record<string, object> = {
     cacheReadInputTokens: null,
     reasoningTokens: null,
     reasoningEffort: "",
+    reasoningEnabled: null,
+    reasoningMaxTokens: null,
     inputMessages: [
       { role: "system", parts: [{ type: "text", content: "You are a friendly assistant." }] },
       { role: "user", parts: [{ type: "text", content: "Hello!" }] },
@@ -415,6 +423,8 @@ const mockSpanDetails: Record<string, object> = {
     cacheReadInputTokens: null,
     reasoningTokens: null,
     reasoningEffort: "",
+    reasoningEnabled: null,
+    reasoningMaxTokens: null,
     inputMessages: [{ role: "user", parts: [] }],
     outputMessages: [],
     finishReasons: [],
@@ -451,6 +461,8 @@ for (const [index, trace] of generatedMockTraces.entries()) {
     cacheReadInputTokens: index % 3 === 0 ? 800 + index * 30 : null,
     reasoningTokens: index % 2 === 0 ? 220 + index * 10 : null,
     reasoningEffort: index % 2 === 0 ? "medium" : "",
+    reasoningEnabled: index % 2 === 0 ? true : null,
+    reasoningMaxTokens: index % 2 === 0 ? 2048 + index * 256 : null,
     inputMessages: [
       {
         role: "system",

--- a/apps/console/app/mocks/routes/traces.ts
+++ b/apps/console/app/mocks/routes/traces.ts
@@ -131,6 +131,7 @@ const mockSpanDetails: Record<string, object> = {
     totalTokens: 1284,
     cacheReadInputTokens: null,
     reasoningTokens: null,
+    reasoningEffort: "",
     inputMessages: [
       {
         role: "system",
@@ -259,6 +260,7 @@ const mockSpanDetails: Record<string, object> = {
     totalTokens: 3584,
     cacheReadInputTokens: 1024,
     reasoningTokens: 512,
+    reasoningEffort: "high",
     inputMessages: [
       {
         role: "system",
@@ -323,6 +325,7 @@ const mockSpanDetails: Record<string, object> = {
     totalTokens: 4096,
     cacheReadInputTokens: null,
     reasoningTokens: null,
+    reasoningEffort: "",
     inputMessages: [
       {
         role: "user",
@@ -369,6 +372,7 @@ const mockSpanDetails: Record<string, object> = {
     totalTokens: 192,
     cacheReadInputTokens: null,
     reasoningTokens: null,
+    reasoningEffort: "",
     inputMessages: [
       { role: "system", parts: [{ type: "text", content: "You are a friendly assistant." }] },
       { role: "user", parts: [{ type: "text", content: "Hello!" }] },
@@ -410,6 +414,7 @@ const mockSpanDetails: Record<string, object> = {
     totalTokens: 256,
     cacheReadInputTokens: null,
     reasoningTokens: null,
+    reasoningEffort: "",
     inputMessages: [{ role: "user", parts: [] }],
     outputMessages: [],
     finishReasons: [],
@@ -445,6 +450,7 @@ for (const [index, trace] of generatedMockTraces.entries()) {
     totalTokens: trace.status === "error" ? 1200 + index * 40 : 1680 + index * 60,
     cacheReadInputTokens: index % 3 === 0 ? 800 + index * 30 : null,
     reasoningTokens: index % 2 === 0 ? 220 + index * 10 : null,
+    reasoningEffort: index % 2 === 0 ? "medium" : "",
     inputMessages: [
       {
         role: "system",

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
@@ -505,6 +505,15 @@ function MetadataView({ trace }: { trace: TraceDetailData }) {
                 label="Finish Reasons"
                 value={trace.finishReasons?.join(", ") ?? null}
               />
+              <IdentifierRow label="Reasoning Effort" value={trace.reasoningEffort || null} />
+              <IdentifierRow
+                label="Reasoning Enabled"
+                value={trace.reasoningEnabled != null ? String(trace.reasoningEnabled) : null}
+              />
+              <IdentifierRow
+                label="Reasoning Max Tokens"
+                value={trace.reasoningMaxTokens != null ? String(trace.reasoningMaxTokens) : null}
+              />
             </tbody>
           </table>
         </div>

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
@@ -505,14 +505,14 @@ function MetadataView({ trace }: { trace: TraceDetailData }) {
                 label="Finish Reasons"
                 value={trace.finishReasons?.join(", ") ?? null}
               />
-              <IdentifierRow label="Reasoning Effort" value={trace.reasoningEffort || null} />
+              <IdentifierRow label="Reasoning Effort" value={trace.reasoningEffort ?? null} />
               <IdentifierRow
                 label="Reasoning Enabled"
-                value={trace.reasoningEnabled != null ? String(trace.reasoningEnabled) : null}
+                value={trace.reasoningEnabled == null ? null : String(trace.reasoningEnabled)}
               />
               <IdentifierRow
                 label="Reasoning Max Tokens"
-                value={trace.reasoningMaxTokens != null ? String(trace.reasoningMaxTokens) : null}
+                value={trace.reasoningMaxTokens == null ? null : String(trace.reasoningMaxTokens)}
               />
             </tbody>
           </table>


### PR DESCRIPTION
## Summary

- The gateway (v0.8.2) records `gen_ai.request.reasoning.effort` as an OTEL span attribute in GreptimeDB, but the `/traces/:traceId` endpoint never selected it — so reasoning effort was silently absent from the API response.
- Added the column to `OPTIONAL_SPAN_COLUMNS` so it's dynamically detected and included in the SQL query when present.
- Added `reasoningEffort` as a field on `SpanDetail`, visible in the raw JSON view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Span details now include three reasoning-related fields in the API and UI: reasoningEffort, reasoningEnabled, and reasoningMaxTokens.
* **Chores**
  * Mock/dev trace data updated so previews and examples include these new fields for realistic testing and visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->