### PR TITLE
Move dev ports to 8520/8524 to avoid conflicts

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,5 @@
-API_URL=http://localhost:4101
-AUTH_URL=http://localhost:4100
+API_URL=http://localhost:8521
+AUTH_URL=http://localhost:8523
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=4101
+PORT=8521

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,5 @@
-API_URL=http://localhost:3001
-AUTH_URL=http://localhost:3000
+API_URL=http://localhost:4101
+AUTH_URL=http://localhost:4100
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=3001
+PORT=4101

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,7 +15,7 @@ import { branchesModule } from "./modules/branches";
 import { providersModule } from "./modules/providers";
 import { spansModule } from "./modules/traces";
 
-const PORT = Number(process.env.PORT ?? 3001);
+const PORT = Number(process.env.PORT ?? 4101);
 const API_URL = process.env.API_URL ?? `http://localhost:${PORT}`;
 
 const createApi = () =>

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,7 +15,7 @@ import { branchesModule } from "./modules/branches";
 import { providersModule } from "./modules/providers";
 import { spansModule } from "./modules/traces";
 
-const PORT = Number(process.env.PORT ?? 4101);
+const PORT = Number(process.env.PORT ?? 8521);
 const API_URL = process.env.API_URL ?? `http://localhost:${PORT}`;
 
 const createApi = () =>

--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -1,4 +1,4 @@
-AUTH_URL=http://localhost:4100
+AUTH_URL=http://localhost:8523
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=4100
+PORT=8523

--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -1,4 +1,4 @@
-AUTH_URL=http://localhost:3000
+AUTH_URL=http://localhost:4100
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=3000
+PORT=4100

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -8,7 +8,7 @@ import { logging } from "@hebo/shared-api/middlewares/logging";
 
 import { auth } from "./better-auth";
 
-const PORT = Number(process.env.PORT ?? 3000);
+const PORT = Number(process.env.PORT ?? 4100);
 
 const createAuth = () =>
   new Elysia()

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -8,7 +8,7 @@ import { logging } from "@hebo/shared-api/middlewares/logging";
 
 import { auth } from "./better-auth";
 
-const PORT = Number(process.env.PORT ?? 4100);
+const PORT = Number(process.env.PORT ?? 8523);
 
 const createAuth = () =>
   new Elysia()

--- a/apps/console/app/lib/env.ts
+++ b/apps/console/app/lib/env.ts
@@ -6,18 +6,18 @@ const isReachable = (url: string) =>
     () => false,
   );
 
-export const useMocks = shouldAutoDetect && !(await isReachable("http://localhost:4101"));
+export const useMocks = shouldAutoDetect && !(await isReachable("http://localhost:8521"));
 
 // oxlint-disable prefer-nullish-coalescing -- empty string should use the fallback URL
 export const apiUrl = useMocks
-  ? "http://localhost:4200/api"
-  : import.meta.env.VITE_API_URL || "http://localhost:4101";
+  ? "http://localhost:8520/api"
+  : import.meta.env.VITE_API_URL || "http://localhost:8521";
 
-export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:4100";
+export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:8523";
 
 export const gatewayUrl = useMocks
-  ? "http://localhost:4200/gateway"
-  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:4102";
+  ? "http://localhost:8520/gateway"
+  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:8522";
 // oxlint-enable prefer-nullish-coalescing
 
 export const magicLinkAuth = import.meta.env.VITE_MAGICLINK_AUTH === "true";

--- a/apps/console/app/lib/env.ts
+++ b/apps/console/app/lib/env.ts
@@ -6,18 +6,18 @@ const isReachable = (url: string) =>
     () => false,
   );
 
-export const useMocks = shouldAutoDetect && !(await isReachable("http://localhost:3001"));
+export const useMocks = shouldAutoDetect && !(await isReachable("http://localhost:4101"));
 
 // oxlint-disable prefer-nullish-coalescing -- empty string should use the fallback URL
 export const apiUrl = useMocks
-  ? "http://localhost:5173/api"
-  : import.meta.env.VITE_API_URL || "http://localhost:3001";
+  ? "http://localhost:4200/api"
+  : import.meta.env.VITE_API_URL || "http://localhost:4101";
 
-export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:3000";
+export const authUrl = import.meta.env.VITE_AUTH_URL || "http://localhost:4100";
 
 export const gatewayUrl = useMocks
-  ? "http://localhost:5173/gateway"
-  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:3002";
+  ? "http://localhost:4200/gateway"
+  : import.meta.env.VITE_GATEWAY_URL || "http://localhost:4102";
 // oxlint-enable prefer-nullish-coalescing
 
 export const magicLinkAuth = import.meta.env.VITE_MAGICLINK_AUTH === "true";

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -10,6 +10,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig(({ mode }) => {
   return {
+    server: { port: 4200 },
     plugins: [
       tsconfigPaths(),
       preserveDirectives(),

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -10,7 +10,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig(({ mode }) => {
   return {
-    server: { port: 4200 },
+    server: { port: 8520 },
     plugins: [
       tsconfigPaths(),
       preserveDirectives(),

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -1,5 +1,5 @@
-AUTH_URL=http://localhost:4100
-GATEWAY_URL=http://localhost:4102
+AUTH_URL=http://localhost:8523
+GATEWAY_URL=http://localhost:8522
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=4102
+PORT=8522

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -1,5 +1,5 @@
-AUTH_URL=http://localhost:3000
-GATEWAY_URL=http://localhost:3002
+AUTH_URL=http://localhost:4100
+GATEWAY_URL=http://localhost:4102
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=3002
+PORT=4102

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -22,7 +22,7 @@ import { prisma } from "~api/middlewares/prisma";
 import { BASE_PATH, gw } from "./gateway";
 import { openaiErrors } from "./middlewares/errors";
 
-const PORT = Number(process.env.PORT ?? 3002);
+const PORT = Number(process.env.PORT ?? 4102);
 const GATEWAY_URL = process.env.GATEWAY_URL ?? `http://localhost:${PORT}`;
 
 export const createGateway = () =>

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -22,7 +22,7 @@ import { prisma } from "~api/middlewares/prisma";
 import { BASE_PATH, gw } from "./gateway";
 import { openaiErrors } from "./middlewares/errors";
 
-const PORT = Number(process.env.PORT ?? 4102);
+const PORT = Number(process.env.PORT ?? 8522);
 const GATEWAY_URL = process.env.GATEWAY_URL ?? `http://localhost:${PORT}`;
 
 export const createGateway = () =>

--- a/apps/mcp/.env.example
+++ b/apps/mcp/.env.example
@@ -1,3 +1,3 @@
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=3003
+PORT=4103

--- a/apps/mcp/.env.example
+++ b/apps/mcp/.env.example
@@ -1,3 +1,3 @@
 LOG_LEVEL=info
 NODE_ENV=development
-PORT=4103
+PORT=8524

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -9,7 +9,7 @@ import { logging } from "@hebo/shared-api/middlewares/logging";
 import { countLetterTool } from "./aikit/count-letter.js";
 import hello from "./hello.txt";
 
-const PORT = Number(process.env.PORT ?? 4103);
+const PORT = Number(process.env.PORT ?? 8524);
 
 function createMcpServer() {
   const mcp = new McpServer({ name: "hebo-mcp", version: "0.0.3" });

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -9,7 +9,7 @@ import { logging } from "@hebo/shared-api/middlewares/logging";
 import { countLetterTool } from "./aikit/count-letter.js";
 import hello from "./hello.txt";
 
-const PORT = Number(process.env.PORT ?? 3003);
+const PORT = Number(process.env.PORT ?? 4103);
 
 function createMcpServer() {
   const mcp = new McpServer({ name: "hebo-mcp", version: "0.0.3" });

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/api/dist/server .
 
-EXPOSE 4101
+EXPOSE 8521
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/api/dist/server .
 
-EXPOSE 3001
+EXPOSE 4101
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.auth
+++ b/infra/docker/Dockerfile.auth
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/auth/dist/server .
 
-EXPOSE 3000
+EXPOSE 4100
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.auth
+++ b/infra/docker/Dockerfile.auth
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/auth/dist/server .
 
-EXPOSE 4100
+EXPOSE 8523
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.gateway
+++ b/infra/docker/Dockerfile.gateway
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/gateway/dist/server .
 
-EXPOSE 3002
+EXPOSE 4102
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.gateway
+++ b/infra/docker/Dockerfile.gateway
@@ -19,6 +19,6 @@ WORKDIR /app
 COPY --from=builder --chown=nonroot:nonroot /rds-bundle.pem /etc/ssl/certs/rds-bundle.pem
 COPY --from=builder /repo/apps/gateway/dist/server .
 
-EXPOSE 4102
+EXPOSE 8522
 USER nonroot:nonroot
 ENTRYPOINT ["/app/server"]

--- a/infra/docker/Dockerfile.mcp
+++ b/infra/docker/Dockerfile.mcp
@@ -17,6 +17,6 @@ WORKDIR /app
 
 COPY --from=builder /repo/apps/mcp/dist/server .
 
-EXPOSE 3003
+EXPOSE 4103
 USER nonroot:nonroot
 CMD ["/app/server"]

--- a/infra/docker/Dockerfile.mcp
+++ b/infra/docker/Dockerfile.mcp
@@ -17,6 +17,6 @@ WORKDIR /app
 
 COPY --from=builder /repo/apps/mcp/dist/server .
 
-EXPOSE 4103
+EXPOSE 8524
 USER nonroot:nonroot
 CMD ["/app/server"]

--- a/infra/stacks/api.ts
+++ b/infra/stacks/api.ts
@@ -7,7 +7,7 @@ import heboDatabase, { createMigrator } from "./db";
 import { authSecret, isProduction, greptimeHost, normalizedStage } from "./env";
 
 const apiDomain = isProduction ? "api.hebo.ai" : `api.${normalizedStage}.hebo.ai`;
-const apiPort = "3001";
+const apiPort = "4101";
 
 const heboApi = new sst.aws.Service("HeboApi", {
   cluster: heboCluster,

--- a/infra/stacks/api.ts
+++ b/infra/stacks/api.ts
@@ -7,7 +7,7 @@ import heboDatabase, { createMigrator } from "./db";
 import { authSecret, isProduction, greptimeHost, normalizedStage } from "./env";
 
 const apiDomain = isProduction ? "api.hebo.ai" : `api.${normalizedStage}.hebo.ai`;
-const apiPort = "4101";
+const apiPort = "8521";
 
 const heboApi = new sst.aws.Service("HeboApi", {
   cluster: heboCluster,

--- a/infra/stacks/auth.ts
+++ b/infra/stacks/auth.ts
@@ -6,7 +6,7 @@ import heboDatabase, { createMigrator } from "./db";
 import { authSecrets, isProduction, greptimeHost, normalizedStage } from "./env";
 
 const authDomain = isProduction ? "auth.hebo.ai" : `auth.${normalizedStage}.hebo.ai`;
-const authPort = "3000";
+const authPort = "4100";
 
 const heboAuth = new sst.aws.Service("HeboAuth", {
   cluster: heboCluster,

--- a/infra/stacks/auth.ts
+++ b/infra/stacks/auth.ts
@@ -6,7 +6,7 @@ import heboDatabase, { createMigrator } from "./db";
 import { authSecrets, isProduction, greptimeHost, normalizedStage } from "./env";
 
 const authDomain = isProduction ? "auth.hebo.ai" : `auth.${normalizedStage}.hebo.ai`;
-const authPort = "4100";
+const authPort = "8523";
 
 const heboAuth = new sst.aws.Service("HeboAuth", {
   cluster: heboCluster,

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -7,7 +7,7 @@ import heboDatabase from "./db";
 import { authSecret, isProduction, llmSecrets, greptimeHost, normalizedStage } from "./env";
 
 const gatewayDomain = isProduction ? "gateway.hebo.ai" : `gateway.${normalizedStage}.hebo.ai`;
-const gatewayPort = "4102";
+const gatewayPort = "8522";
 
 const heboGateway = new sst.aws.Service("HeboGateway", {
   cluster: heboCluster,

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -7,7 +7,7 @@ import heboDatabase from "./db";
 import { authSecret, isProduction, llmSecrets, greptimeHost, normalizedStage } from "./env";
 
 const gatewayDomain = isProduction ? "gateway.hebo.ai" : `gateway.${normalizedStage}.hebo.ai`;
-const gatewayPort = "3002";
+const gatewayPort = "4102";
 
 const heboGateway = new sst.aws.Service("HeboGateway", {
   cluster: heboCluster,

--- a/infra/stacks/mcp.ts
+++ b/infra/stacks/mcp.ts
@@ -5,7 +5,7 @@ import heboCluster from "./cluster";
 import { isProduction, greptimeHost, authSecret, normalizedStage } from "./env";
 
 const mcpDomain = isProduction ? "mcp.hebo.ai" : `mcp.${normalizedStage}.hebo.ai`;
-const mcpPort = "4103";
+const mcpPort = "8524";
 
 const heboMcp = new sst.aws.Service("HeboMcp", {
   cluster: heboCluster,

--- a/infra/stacks/mcp.ts
+++ b/infra/stacks/mcp.ts
@@ -5,7 +5,7 @@ import heboCluster from "./cluster";
 import { isProduction, greptimeHost, authSecret, normalizedStage } from "./env";
 
 const mcpDomain = isProduction ? "mcp.hebo.ai" : `mcp.${normalizedStage}.hebo.ai`;
-const mcpPort = "3003";
+const mcpPort = "4103";
 
 const heboMcp = new sst.aws.Service("HeboMcp", {
   cluster: heboCluster,

--- a/packages/shared-api/env.ts
+++ b/packages/shared-api/env.ts
@@ -1,7 +1,7 @@
 import { parseLogSeverity } from "./utils/otel-pino";
 import { getSecret } from "./utils/secret";
 
-export const AUTH_URL = process.env.AUTH_URL ?? "http://localhost:4100";
+export const AUTH_URL = process.env.AUTH_URL ?? "http://localhost:8523";
 export const IS_PRODUCTION = process.env.NODE_ENV === "production";
 export const LOG_LEVEL = process.env.LOG_LEVEL ?? (IS_PRODUCTION ? "info" : "debug");
 export const LOG_SEVERITY = parseLogSeverity(LOG_LEVEL);

--- a/packages/shared-api/env.ts
+++ b/packages/shared-api/env.ts
@@ -1,7 +1,7 @@
 import { parseLogSeverity } from "./utils/otel-pino";
 import { getSecret } from "./utils/secret";
 
-export const AUTH_URL = process.env.AUTH_URL ?? "http://localhost:3000";
+export const AUTH_URL = process.env.AUTH_URL ?? "http://localhost:4100";
 export const IS_PRODUCTION = process.env.NODE_ENV === "production";
 export const LOG_LEVEL = process.env.LOG_LEVEL ?? (IS_PRODUCTION ? "info" : "debug");
 export const LOG_SEVERITY = parseLogSeverity(LOG_LEVEL);


### PR DESCRIPTION
## Summary

Migrates all default dev ports from the heavily contested 3000–3003 and 5173 ranges to **8520–8524**, a branded range that encodes HEBO (H=8, E=5, B=2, O=0) and nods to **8**monkey in the leading digit.

### New port map

| Service | Before | After |
|---------|--------|-------|
| console | 5173 | **8520** |
| api | 3001 | **8521** |
| gateway | 3002 | **8522** |
| auth | 3000 | **8523** |
| mcp | 3003 | **8524** |

### Why these ports

**Collision-free.** Ports 3000–3003 are defaults for Express, Next.js, Rails, Remix, Astro, CRA, and many others. Port 5173 is Vite's default (shared by Nuxt, SvelteKit, etc). Running any side-project alongside Hebo causes `EADDRINUSE`. The `85xx` range is largely clean — `8500` (Consul HTTP API) is the only nearby default, and we start at 8520.

**Branded mnemonic.** `8520` = HEBO in letter positions (H=8th, E=5th, B=2nd, O→0). The `8` prefix also directly references 8monkey. One mnemonic covers all five ports.

**Fits service conventions.** The `8xxx` block is the de-facto range for internal service HTTP ports. Compared to `8080` (Tomcat), `8000` (Django), `8888` (Jupyter), `8443` (HTTPS alt) — all taken. `8520–8524` is a clear gap.

### What changed

Updated across all layers that define or reference ports:
- **Source code** — `process.env.PORT ?? <port>` fallbacks in each service's `index.ts`
- **`.env.example` templates** — tracked env templates for all four backend services
- **Console** — `env.ts` hardcoded fallbacks + `vite.config.ts` server port
- **Dockerfiles** — `EXPOSE` directives for auth, api, gateway, mcp
- **SST infra stacks** — `authPort`, `apiPort`, `gatewayPort`, `mcpPort` constants
- **`packages/shared-api`** — `AUTH_URL` fallback in `env.ts`

### After merging

Each developer should update their local (gitignored) `.env` files to use the new ports. Running `bun run dev` will use the new defaults automatically for anyone who relies on the fallbacks.

## Test plan

- [x] `bun run dev` starts all services on the new ports (8520–8524)
- [x] Console auto-detects mock mode correctly against port 8521
- [x] `bun run build` completes without errors
- [x] SST preview deployment starts all services on the new ports (no health-check or LB forwarding errors)
- [x] Verify no remaining references to old ports: `rg 'localhost:300[0-3]|localhost:5173' --type-not=md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default port numbers for all services across the platform, including API, authentication, gateway, and MCP. Configuration files, Docker container definitions, and infrastructure stacks have been updated accordingly. Users with custom local development setups should verify their environment configuration matches the new service port allocations for proper operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->