### PR TITLE
upgrade @elysiajs/opentelemetry to ^1.4.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -259,7 +259,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/eden": "^1.4.8",
     "@elysiajs/openapi": "^1.4.14",
-    "@elysiajs/opentelemetry": "^1.4.10",
+    "@elysiajs/opentelemetry": "^1.4.11",
     "@opentelemetry/api": "^1.9.0",
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
@@ -493,7 +493,7 @@
 
     "@elysiajs/openapi": ["@elysiajs/openapi@1.4.14", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw=="],
 
-    "@elysiajs/opentelemetry": ["@elysiajs/opentelemetry@1.4.10", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/instrumentation": "^0.200.0", "@opentelemetry/sdk-node": "^0.200.0" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-2GH187Rr3n3Rq+R7fogn/jcmdwWk9OMtbYhnaJg5ydiLOJvtrztDp0p+zbyGFG2gspx8U9vpaCvSJ69Aq1zZkA=="],
+    "@elysiajs/opentelemetry": ["@elysiajs/opentelemetry@1.4.11", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/instrumentation": "^0.200.0", "@opentelemetry/sdk-node": "^0.200.0" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-GGggB40rXithCA9nSjSc25TFkBPeEEW3rD8me/TrRq4TejzWFJn5zEKdRMYWSpYBeiUsraCpQxu94K2ASz+UnA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/eden": "^1.4.8",
     "@elysiajs/openapi": "^1.4.14",
-    "@elysiajs/opentelemetry": "^1.4.10",
+    "@elysiajs/opentelemetry": "^1.4.11",
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
     "@prisma/instrumentation": "^7.4.2",


### PR DESCRIPTION
Closes #336

Bumps `@elysiajs/opentelemetry` from `^1.4.10` to `^1.4.11` in the root workspace catalog and regenerates the lockfile.

## Verification

- All workspaces build successfully (api, auth, gateway, mcp, console)
- Typecheck passes with 0 errors across all workspaces
- No code changes needed — dependency requirements are unchanged
- Manual smoke-testing of service startup and trace export recommended

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry-related dependency to the latest patch version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->