### PR TITLE
Set compaction memory limit on GreptimeDB datanodes

### DIFF
--- a/infra/k8s/greptime/greptime-values.yaml
+++ b/infra/k8s/greptime/greptime-values.yaml
@@ -28,6 +28,11 @@ meta:
 
 datanode:
   replicas: 3
+  configData: |
+    [[region_engine]]
+    [region_engine.mito]
+    experimental_compaction_memory_limit = "500MB"
+    experimental_compaction_on_exhausted = "fail"
   podTemplate:
     serviceAccount:
       create: true


### PR DESCRIPTION
## Summary

- Adds `experimental_compaction_memory_limit = "500MB"` and `experimental_compaction_on_exhausted = "fail"` to the datanode config in `greptime-values.yaml`
- Prevents OOMKill by capping memory used by TWCS compaction and failing the compaction task (instead of the whole pod) when the budget is exhausted

## Context

Datanodes were being OOMKilled (exit code 137) during TWCS compaction. Root cause: compaction reads SST files containing large JSON span attributes (avg ~50 KB, max ~1.2 MB per row in `gen_ai.input.messages`) with no memory budget, eventually consuming all available node memory. The GreptimeDB team recommended these experimental settings as a workaround.

Relates to #321.

## Test plan

- [x] Already applied to the EKS cluster via `helm upgrade` (revision 4)
- [x] All 3 datanodes rolling-restarted successfully
- [x] Config verified in datanode ConfigMap
- [x] Health check passed
- [x] Monitor for OOMKill recurrence over the next few days

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes infrastructure configuration for data compaction behavior and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->