### PR TITLE
fix(gateway): Bedrock BYOK must not inherit AWS_SESSION_TOKEN (IRSA)

### DIFF
--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -97,6 +97,8 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
         case "access-key": {
           const { accessKeyId, secretAccessKey } = bedrockConfig;
           if (!accessKeyId || !secretAccessKey) return;
+          // credentialProvider: passing keys alone still merges AWS_SESSION_TOKEN from
+          // the process env (IRSA, etc.); see https://github.com/vercel/ai/issues/14136
           return withCanonicalIdsForBedrock(
             createAmazonBedrock({
               region,

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -97,7 +97,6 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
         case "access-key": {
           const { accessKeyId, secretAccessKey } = bedrockConfig;
           if (!accessKeyId || !secretAccessKey) return;
-          // See #351: credentialProvider avoids AWS_SESSION_TOKEN from IRSA + BYOK key mix-up.
           return withCanonicalIdsForBedrock(
             createAmazonBedrock({
               region,

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -97,8 +97,12 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV3 
         case "access-key": {
           const { accessKeyId, secretAccessKey } = bedrockConfig;
           if (!accessKeyId || !secretAccessKey) return;
+          // See #351: credentialProvider avoids AWS_SESSION_TOKEN from IRSA + BYOK key mix-up.
           return withCanonicalIdsForBedrock(
-            createAmazonBedrock({ region, accessKeyId, secretAccessKey }),
+            createAmazonBedrock({
+              region,
+              credentialProvider: () => Promise.resolve({ accessKeyId, secretAccessKey }),
+            }),
           );
         }
         case "iam-role": {


### PR DESCRIPTION
## Summary

Fixes #351.

`@ai-sdk/amazon-bedrock` builds SigV4 credentials from `accessKeyId` / `secretAccessKey` but still loads `AWS_SESSION_TOKEN` from the environment when no `sessionToken` option is set. On EKS/IRSA that merges the pod session token with BYOK IAM user keys and AWS rejects the request.

## Change

Use `credentialProvider: () => Promise.resolve({ accessKeyId, secretAccessKey })` for Bedrock `access-key` mode so only those fields are supplied (no env session token).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how Bedrock access-key authentication supplies credentials: the access-key flow now provides credentials via an asynchronous provider callback (while still validating required fields). This is an internal credential-handling change with no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->