### PR TITLE
fix: prevent wrong model removal due to stale form state

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -67,7 +67,6 @@ export default function ModelsConfigForm({
   const fetcher = useFetcher<typeof clientAction>();
 
   const [form, fields] = useForm<ModelsConfigFormValues>({
-    key: JSON.stringify(models),
     lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
     constraint: getZodConstraint(modelsConfigFormSchema),
     defaultValue: { models },
@@ -86,7 +85,7 @@ export default function ModelsConfigForm({
   const formRef = useRef<HTMLFormElement>(null);
 
   return (
-    <FormControl form={form} as={fetcher.Form} ref={formRef} className="flex flex-col gap-4">
+    <FormControl key={JSON.stringify(models)} form={form} as={fetcher.Form} ref={formRef} className="flex flex-col gap-4">
       <button type="submit" hidden aria-hidden="true" tabIndex={-1} disabled={!form.dirty} />
 
       {fields.models.getFieldList().map((model, index) => (

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -67,6 +67,7 @@ export default function ModelsConfigForm({
   const fetcher = useFetcher<typeof clientAction>();
 
   const [form, fields] = useForm<ModelsConfigFormValues>({
+    key: JSON.stringify(models),
     lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
     constraint: getZodConstraint(modelsConfigFormSchema),
     defaultValue: { models },


### PR DESCRIPTION
Fixes #332

Adds a `key` prop to the `useForm` hook in the model config form, derived from the server-provided models. This forces Conform to re-initialize when models update after revalidation, preventing stale `initialValue` from causing `form.reset()` to drop newly added models.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form behavior in the models configuration so the form reliably updates and rebinds when switching between different model sets, ensuring controls reset to the correct model-specific values while preserving submit/reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->