### PR TITLE
fix: guard lastResult with navigation.state to prevent stale form reset

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -2,7 +2,7 @@ import { useForm, type FieldMetadata } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
 import { Brain, ChevronsUpDown, Edit, Info } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Link, useFetcher } from "react-router";
+import { Link, useFetcher, useNavigation } from "react-router";
 import { useSnapshot } from "valtio";
 
 import { Alert, AlertDescription } from "@hebo/shared-ui/components/Alert";
@@ -65,9 +65,10 @@ export default function ModelsConfigForm({
   providers,
 }: ModelsConfigProps) {
   const fetcher = useFetcher<typeof clientAction>();
+  const navigation = useNavigation();
 
   const [form, fields] = useForm<ModelsConfigFormValues>({
-    lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
+    lastResult: fetcher.state === "idle" && navigation.state === "idle" ? fetcher.data : undefined,
     constraint: getZodConstraint(modelsConfigFormSchema),
     defaultValue: { models },
   });


### PR DESCRIPTION
Fixes #332

Adds a `navigation.state === "idle"` guard to the `lastResult` prop in `useForm`, per Conform's Remix integration docs. This ensures Conform only processes the action result (including `resetForm`) after parent route revalidation completes, preventing stale `initialValue` from causing the wrong model to be removed.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed form behavior to properly account for page navigation state, preventing form results from displaying incorrectly during navigation transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->