### PR TITLE
fix: guard lastResult with navigation.state and close dialog on remove confirm

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -91,7 +91,7 @@ export default function ModelsConfigForm({
 
       {fields.models.getFieldList().map((model, index) => (
         <ModelCard
-          key={model.name}
+          key={model.key}
           model={model}
           agentSlug={agentSlug}
           branchSlug={branchSlug}

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.models/form.tsx
@@ -2,7 +2,7 @@ import { useForm, type FieldMetadata } from "@conform-to/react";
 import { getZodConstraint } from "@conform-to/zod/v4";
 import { Brain, ChevronsUpDown, Edit, Info } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Link, useFetcher } from "react-router";
+import { Link, useFetcher, useNavigation } from "react-router";
 import { useSnapshot } from "valtio";
 
 import { Alert, AlertDescription } from "@hebo/shared-ui/components/Alert";
@@ -65,9 +65,10 @@ export default function ModelsConfigForm({
   providers,
 }: ModelsConfigProps) {
   const fetcher = useFetcher<typeof clientAction>();
+  const navigation = useNavigation();
 
   const [form, fields] = useForm<ModelsConfigFormValues>({
-    lastResult: fetcher.state === "idle" ? fetcher.data : undefined,
+    lastResult: fetcher.state === "idle" && navigation.state === "idle" ? fetcher.data : undefined,
     constraint: getZodConstraint(modelsConfigFormSchema),
     defaultValue: { models },
   });
@@ -338,14 +339,18 @@ function ModelCard(props: {
                     }
                   />
 
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    onClick={onRemove}
-                    isLoading={isSubmitting}
-                  >
-                    Remove
-                  </Button>
+                  <DialogClose
+                    render={
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={onRemove}
+                        isLoading={isSubmitting}
+                      >
+                        Remove
+                      </Button>
+                    }
+                  />
                 </DialogFooter>
               </DialogContent>
             </Dialog>


### PR DESCRIPTION
Fixes #332

Two changes to fix the model removal bug:

1. Guard `lastResult` with `navigation.state === "idle"` per Conform's Remix integration docs. This ensures Conform only processes the action result (including `resetForm`) after parent route revalidation completes, preventing stale `initialValue` from causing `form.reset()` to drop newly added models.

2. Wrap the confirm Remove button in `DialogClose` so the dialog dismisses when the user confirms the removal.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale form results from appearing during route/navigation transitions by ensuring form state only updates when navigation is idle.
  * Improved model list rendering to avoid unstable item identity during updates.
  * Improved the "Remove model" confirmation dialog so it reliably closes and shows operation progress while the removal runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->