### PR TITLE
chore: update greptimedb image version to v1.0.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
 
   greptimedb:
     container_name: greptime
-    image: greptime/greptimedb:v1.0.0-rc.2-nightly-20260323
+    image: greptime/greptimedb:v1.0.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:4000:4000"

--- a/infra/stacks/greptime.ts
+++ b/infra/stacks/greptime.ts
@@ -11,7 +11,7 @@ const heboGreptime = isProduction
       architecture: "arm64",
       cpu: "0.25 vCPU",
       memory: "0.5 GB",
-      image: "greptime/greptimedb:v1.0.0-rc.2-nightly-20260323",
+      image: "greptime/greptimedb:v1.0.0",
       command: [
         "standalone",
         "start",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GreptimeDB service container image to version 1.0.0 across all deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->