### PR TITLE
fix(ci): pin claude-code-action to v1.0.89

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,7 +53,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.89 # pinned: v1.0.90 broke Bedrock OIDC auth (anthropics/claude-code-action#1196)
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"


### PR DESCRIPTION
## Summary

- Pins `anthropics/claude-code-action` from `@v1` (floating) to `@v1.0.89` to work around a Bedrock SigV4 authentication regression introduced in v1.0.90.
- The upstream bug causes `403 Authorization header requires 'Credential' parameter` errors when using OIDC-assumed AWS credentials with Bedrock.

## Context

- Upstream issue: https://github.com/anthropics/claude-code-action/issues/1196
- Upstream fix landed in Claude Code 2.1.97 (https://github.com/anthropics/claude-code-action/issues/1193) but the `@v1` tag has not been updated yet.
- Once the upstream `@v1` tag includes the fix, we can unpin back to `@v1`.

## Test plan

- [x] Verified last successful run used action SHA `6e2bd52` (v1.0.89)
- [x] Verified all failures started after action SHA changed to `26ddc35` (v1.0.90)
- [ ] Trigger `@claude` on an issue/PR comment after merge and confirm it succeeds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions workflow version to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->