### PR TITLE
integrate @8monkey/opentelemetry-instrumentation-bun-sql

### DIFF
--- a/apps/gateway/src/gateway.ts
+++ b/apps/gateway/src/gateway.ts
@@ -86,6 +86,7 @@ export const gw = gateway({
     onError: bestEffortResolveModelOnError,
   },
 
+  // FUTURE change severity from `trace` to `info` to avoid leaking sensitive information
   logger: createPinoOtelAdapter(createOtelLogger("hebo-gateway", 1)), // trace severity
 
   timeouts: {

--- a/bun.lock
+++ b/bun.lock
@@ -193,6 +193,7 @@
       "name": "@hebo/shared-api",
       "version": "0.0.1",
       "dependencies": {
+        "@8monkey/opentelemetry-instrumentation-bun-sql": "^0.1.0-rc0",
         "@opentelemetry/api": "catalog:",
         "@opentelemetry/api-logs": "^0.212.0",
         "@opentelemetry/exporter-logs-otlp-proto": "^0.212.0",
@@ -289,6 +290,8 @@
   },
   "packages": {
     "@8monkey/elysia-mcp": ["@8monkey/elysia-mcp@0.1.0-rc0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0" }, "peerDependencies": { "elysia": "^1.4.0" } }, "sha512-Ei4o/ak56Nld4/qTr8whDVS0QNFanq7xMcxRdB1OnQFhGfRX2UUFKTbinap4kUQX9OFUnBvqI66rrvogmgY4QQ=="],
+
+    "@8monkey/opentelemetry-instrumentation-bun-sql": ["@8monkey/opentelemetry-instrumentation-bun-sql@0.1.0-rc0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCZI6eQj5whHvGSPTvCUnwMvmR5/Rm7L3Z0SfrRezJXESLfxUCJHfbGsAo8XiDMFyBZPVZryySfwg2ZTFBEiJQ=="],
 
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.77", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.58", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PKLqycbq4NHCasZ0454HZh58thDGsqEKnpkXYr+Ym4Y4YFL3vhLUwhvvZeuOfawVdmMijQfRiKeAZhd2XtTkOg=="],
 
@@ -715,6 +718,8 @@
     "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.0.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.0.0", "@opentelemetry/core": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
+
+    "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -2902,6 +2907,8 @@
 
     "@8monkey/elysia-mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@8monkey/opentelemetry-instrumentation-bun-sql/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
     "@ai-sdk/amazon-bedrock/aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -3073,6 +3080,8 @@
     "@opentelemetry/sdk-trace-node/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw=="],
+
+    "@opentelemetry/sql-common/@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
 
     "@prisma/dev/hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
 
@@ -3287,6 +3296,12 @@
     "@8monkey/elysia-mcp/@modelcontextprotocol/sdk/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "@8monkey/elysia-mcp/@modelcontextprotocol/sdk/raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "@8monkey/opentelemetry-instrumentation-bun-sql/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@8monkey/opentelemetry-instrumentation-bun-sql/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
+
+    "@8monkey/opentelemetry-instrumentation-bun-sql/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -3537,6 +3552,8 @@
     "@8monkey/elysia-mcp/@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "@8monkey/elysia-mcp/@modelcontextprotocol/sdk/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "@8monkey/opentelemetry-instrumentation-bun-sql/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/packages/shared-api/db/greptime.ts
+++ b/packages/shared-api/db/greptime.ts
@@ -1,5 +1,3 @@
-import type { SQL } from "bun";
-
 import { getSecret } from "../utils/secret";
 import { DEFAULT_DB_IDLE_TIMEOUT_MS, DEFAULT_DB_POOL_MAX } from "./config";
 
@@ -18,4 +16,4 @@ export const createBunSqlClient = (url: string) => {
 
 export const greptimeSqlClient = createBunSqlClient(await getGreptimeConnectionString());
 
-export type BunSqlClient = InstanceType<typeof SQL>;
+export type BunSqlClient = ReturnType<typeof createBunSqlClient>;

--- a/packages/shared-api/db/greptime.ts
+++ b/packages/shared-api/db/greptime.ts
@@ -1,4 +1,4 @@
-import { SQL } from "bun";
+import type { SQL } from "bun";
 
 import { getSecret } from "../utils/secret";
 import { DEFAULT_DB_IDLE_TIMEOUT_MS, DEFAULT_DB_POOL_MAX } from "./config";
@@ -7,12 +7,14 @@ export const getGreptimeConnectionString = async () => {
   return `postgres://${(await getSecret("GreptimeHost")) ?? "localhost"}:4003/public`;
 };
 
-export const createBunSqlClient = (url: string) =>
-  new SQL({
+export const createBunSqlClient = (url: string) => {
+  const { SQL } = require("bun") as typeof Bun;
+  return new SQL({
     url,
     max: DEFAULT_DB_POOL_MAX,
     idleTimeout: DEFAULT_DB_IDLE_TIMEOUT_MS / 1_000,
   });
+};
 
 export const greptimeSqlClient = createBunSqlClient(await getGreptimeConnectionString());
 

--- a/packages/shared-api/lib/otel.ts
+++ b/packages/shared-api/lib/otel.ts
@@ -18,6 +18,7 @@ import {
   type SpanExporter,
   BatchSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
+import { BunSqlInstrumentation } from "@8monkey/opentelemetry-instrumentation-bun-sql";
 import { PrismaInstrumentation, registerInstrumentations } from "@prisma/instrumentation";
 
 import { IS_PRODUCTION } from "../env";
@@ -77,6 +78,11 @@ registerInstrumentations({
         "prisma:engine:db_query",
         "prisma:engine:connection",
       ],
+    }),
+    new BunSqlInstrumentation({
+      requireParentSpan: true,
+      ignoreConnectionSpans: true,
+      maskStatement: false,
     }),
   ],
 });

--- a/packages/shared-api/lib/otel.ts
+++ b/packages/shared-api/lib/otel.ts
@@ -1,3 +1,4 @@
+import { BunSqlInstrumentation } from "@8monkey/opentelemetry-instrumentation-bun-sql";
 import type { ElysiaOpenTelemetryOptions } from "@elysiajs/opentelemetry";
 import type { SeverityNumber } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
@@ -18,7 +19,6 @@ import {
   type SpanExporter,
   BatchSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { BunSqlInstrumentation } from "@8monkey/opentelemetry-instrumentation-bun-sql";
 import { PrismaInstrumentation, registerInstrumentations } from "@prisma/instrumentation";
 
 import { IS_PRODUCTION } from "../env";
@@ -82,6 +82,7 @@ registerInstrumentations({
     new BunSqlInstrumentation({
       requireParentSpan: true,
       ignoreConnectionSpans: true,
+      // FUTURE: set to true to avoid leaking sensitive information
       maskStatement: false,
     }),
   ],

--- a/packages/shared-api/package.json
+++ b/packages/shared-api/package.json
@@ -18,6 +18,7 @@
     "typecheck": "oxlint --type-aware --type-check"
   },
   "dependencies": {
+    "@8monkey/opentelemetry-instrumentation-bun-sql": "^0.1.0-rc0",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/api-logs": "^0.212.0",
     "@opentelemetry/exporter-logs-otlp-proto": "^0.212.0",


### PR DESCRIPTION
Integrate `@8monkey/opentelemetry-instrumentation-bun-sql` to add OpenTelemetry spans for all Bun.SQL queries to GreptimeDB.

Changes:
- Register `BunSqlInstrumentation` alongside `PrismaInstrumentation` in `otel.ts` with `maskStatement: false`
- Move `require("bun")` inside `createBunSqlClient` to guarantee instrumentation patches before SQL constructor capture
- Type-only import at top level for `BunSqlClient` type export

Closes #377

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic SQL operation tracing for improved observability of database interactions.
  * Optimized SQL client initialization through lazy-loading mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->