### PR TITLE
fix(gateway): use environment-appropriate log severity instead of hardcoded trace

### DIFF
--- a/apps/gateway/src/gateway.ts
+++ b/apps/gateway/src/gateway.ts
@@ -7,6 +7,7 @@ import { voyage35 } from "@hebo-ai/gateway/models/voyage";
 import { instrumentFetch } from "@hebo-ai/gateway/telemetry";
 import { trace } from "@opentelemetry/api";
 
+import { LOG_SEVERITY } from "@hebo/shared-api/env";
 import { createOtelLogger } from "@hebo/shared-api/lib/otel";
 import { createPinoOtelAdapter } from "@hebo/shared-api/utils/otel-pino";
 
@@ -86,8 +87,7 @@ export const gw = gateway({
     onError: bestEffortResolveModelOnError,
   },
 
-  // FUTURE change severity from `trace` to `info` to avoid leaking sensitive information
-  logger: createPinoOtelAdapter(createOtelLogger("hebo-gateway", 1)), // trace severity
+  logger: createPinoOtelAdapter(createOtelLogger("hebo-gateway", LOG_SEVERITY)),
 
   timeouts: {
     flex: 30 * 60_000, // 30 minutes


### PR DESCRIPTION
Replace hardcoded trace severity (1) with `LOG_SEVERITY` from `@hebo/shared-api/env`, which defaults to `info` in production and `debug` in development.

Closes #379

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway logging configuration to use environment-based settings instead of hard-coded values, improving configuration maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->