### PR TITLE
chore: use forked @elysiajs/opentelemetry with pending upstream patches

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -259,7 +259,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/eden": "^1.4.8",
     "@elysiajs/openapi": "^1.4.14",
-    "@elysiajs/opentelemetry": "^1.4.11",
+    "@elysiajs/opentelemetry": "github:turisanapo/opentelemetry#fork/main",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "^0.214.0",
     "@opentelemetry/instrumentation-pg": "^0.66.0",
@@ -503,7 +503,7 @@
 
     "@elysiajs/openapi": ["@elysiajs/openapi@1.4.14", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw=="],
 
-    "@elysiajs/opentelemetry": ["@elysiajs/opentelemetry@1.4.11", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/instrumentation": "^0.200.0", "@opentelemetry/sdk-node": "^0.200.0" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-GGggB40rXithCA9nSjSc25TFkBPeEEW3rD8me/TrRq4TejzWFJn5zEKdRMYWSpYBeiUsraCpQxu94K2ASz+UnA=="],
+    "@elysiajs/opentelemetry": ["@elysiajs/opentelemetry@github:turisanapo/opentelemetry#dd57bd3", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/instrumentation": "^0.200.0", "@opentelemetry/sdk-node": "^0.200.0" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "turisanapo-opentelemetry-dd57bd3"],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/eden": "^1.4.8",
     "@elysiajs/openapi": "^1.4.14",
-    "@elysiajs/opentelemetry": "^1.4.11",
+    "@elysiajs/opentelemetry": "github:turisanapo/opentelemetry#fork/main",
     "@prisma/adapter-pg": "^7.4.2",
     "@prisma/client": "^7.4.2",
     "@opentelemetry/instrumentation": "^0.214.0",

--- a/packages/shared-api/lib/otel.ts
+++ b/packages/shared-api/lib/otel.ts
@@ -14,11 +14,7 @@ import {
   createLoggerConfigurator,
 } from "@opentelemetry/sdk-logs";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import {
-  type BufferConfig,
-  type SpanExporter,
-  BatchSpanProcessor,
-} from "@opentelemetry/sdk-trace-base";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 
@@ -26,10 +22,32 @@ import { IS_PRODUCTION } from "../env";
 import { getSecret } from "../utils/secret";
 import { isRootPathUrl } from "../utils/url";
 
-const SENSITIVE_SPAN_ATTRIBUTES = [
-  "http.request.header.authorization",
-  "http.request.header.cookie",
-  "http.request.cookie",
+/**
+ * Headers that are safe and useful to record as span attributes.
+ * The fork's safe-by-default behavior excludes all headers unless explicitly
+ * listed here — no sensitive data (Authorization, Cookie, etc.) is ever recorded.
+ */
+const ALLOWED_REQUEST_HEADERS = [
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "cache-control",
+  "content-length",
+  "content-type",
+  "host",
+  "origin",
+  "referer",
+  "user-agent",
+  "x-forwarded-for",
+  "x-forwarded-proto",
+  "x-request-id",
+];
+
+const ALLOWED_RESPONSE_HEADERS = [
+  "content-length",
+  "content-type",
+  "cache-control",
+  "x-request-id",
 ];
 
 export const GREPTIME_OTLP_ENDPOINT = `http://${(await getSecret("GREPTIME_HOST")) ?? "localhost"}:4000/v1/otlp`;
@@ -81,30 +99,13 @@ registerInstrumentations({
   ],
 });
 
-const REDACTED = "[REDACTED]";
-
-const createRedactingBatchSpanProcessor = (exporter: SpanExporter, config?: BufferConfig) => {
-  const processor = new BatchSpanProcessor(exporter, config);
-  const originalOnEnd = processor.onEnd.bind(processor);
-  const keys = SENSITIVE_SPAN_ATTRIBUTES;
-
-  processor.onEnd = (span) => {
-    const attrs = span.attributes as Record<string, unknown>;
-
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      if (attrs[key] !== undefined) attrs[key] = REDACTED;
-    }
-
-    originalOnEnd(span);
-  };
-
-  return processor;
-};
-
 export const getOtelConfig = (serviceName: string): ElysiaOpenTelemetryOptions => {
   return {
     serviceName,
+    headersToSpanAttributes: {
+      requestHeaders: ALLOWED_REQUEST_HEADERS,
+      responseHeaders: ALLOWED_RESPONSE_HEADERS,
+    },
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({
         url: `${GREPTIME_OTLP_ENDPOINT}/v1/metrics`,
@@ -116,7 +117,7 @@ export const getOtelConfig = (serviceName: string): ElysiaOpenTelemetryOptions =
       return !isRootPathUrl(request.url);
     },
     spanProcessors: [
-      createRedactingBatchSpanProcessor(
+      new BatchSpanProcessor(
         new OTLPTraceExporter({
           url: `${GREPTIME_OTLP_ENDPOINT}/v1/traces`,
           headers: { "x-greptime-pipeline-name": "greptime_trace_v1" },

--- a/packages/shared-api/lib/otel.ts
+++ b/packages/shared-api/lib/otel.ts
@@ -36,9 +36,7 @@ const ALLOWED_REQUEST_HEADERS = [
   "content-type",
   "host",
   "origin",
-  "referer",
   "user-agent",
-  "x-forwarded-for",
   "x-forwarded-proto",
   "x-request-id",
 ];


### PR DESCRIPTION
Switch the workspace catalog entry from the registry version to the turisanapo/opentelemetry fork (fork/main branch) which includes PRs #74 (safe-by-default span attributes) and #76 (http.server.request.duration histogram metric).

Closes #389

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to use an alternative source.
* **Bug Fixes**
  * Telemetry/span handling updated to use explicit allowlists for which headers become span attributes; span processor instantiation simplified to avoid per-span mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->