### PR TITLE
move docs folder from www to platform

### DIFF
--- a/docs/changelog/updates.mdx
+++ b/docs/changelog/updates.mdx
@@ -1,0 +1,26 @@
+---
+title: "Updates"
+---
+
+## Gateway v0.1
+
+- /chat/completions, /embeddings and /models endpoints
+- OpenAI compatibility for all endpoints
+- Reasoning and tool calling support
+- Streaming and non-streaming responses
+- Managed models: Gemini 3, GPT-OSS, Voyage 3.5
+- Ability to create aliases for models
+- BYOK for Groq, Google Vertex, Amazon Bedrock
+
+## MCP v0.1
+
+- Pre-hosted MCP server with real tools for immediate use
+- Built to cover tasks agents struggle with like counting letters
+- Simple integration with the Vercel AI SDK and other clients
+
+## Evals v0.1
+
+- Write test cases as simple markdown
+- Reuse system prompts across multiple test cases
+- Configurable scoring thresholds & test execution count
+- CLI integratable into any CI/CD pipeline

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "maple",
+  "name": "Hebo AI",
+  "colors": {
+    "primary": "#3b82f6",
+    "light": "#fde047",
+    "dark": "#facc15"
+  },
+  "background": {
+    "color": {
+      "light": "#f8fafc",
+      "dark": "#020617"
+    }
+  },
+  "logo": {
+    "light": "https://hebo.ai/logo.png",
+    "dark": "https://hebo.ai/logo-dark.png"
+  },
+  "favicon": "https://hebo.ai/favicon.svg",
+  "icons": {
+    "library": "lucide"
+  },
+  "appearance": {
+    "default": "light"
+  },
+  "fonts": {
+    "family": "Recursive"
+  },
+  "navbar": {
+    "primary": {
+      "type": "github",
+      "href": "https://github.com/8monkey-ai/hebo-gateway/"
+    }
+  },
+  "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Gateway",
+          "icon": "brain-circuit",
+          "href": "https://hebo.ai/gateway"
+        },
+        {
+          "anchor": "MCP",
+          "icon": "square-function",
+          "href": "https://hebo.ai/mcp"
+        },
+        {
+          "anchor": "Evals",
+          "icon": "gauge",
+          "href": "https://hebo.ai/evals"
+        }
+      ]
+    },
+    "groups": [
+      {
+        "group": "Overview",
+        "pages": ["introduction"]
+      },
+      {
+        "group": "Gateway",
+        "icon": "brain-circuit",
+        "pages": [
+          "gateway/quick-start",
+          "gateway/streaming",
+          "gateway/tool-calling",
+          "gateway/structured-outputs",
+          "gateway/reasoning",
+          "gateway/attachments",
+          "gateway/embeddings",
+          "gateway/supported-models"
+        ]
+      },
+      {
+        "group": "MCP",
+        "icon": "square-function",
+        "pages": ["mcp/aikit"]
+      },
+      {
+        "group": "Evals",
+        "icon": "gauge",
+        "pages": ["evals/getting-started"]
+      },
+      {
+        "group": "Changelog",
+        "icon": "calendar-days",
+        "pages": ["changelog/updates"]
+      }
+    ]
+  },
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "mcp", "vscode", "cursor"]
+  },
+  "footer": {
+    "socials": {
+      "x": "https://x.com/heboai",
+      "github": "https://github.com/8monkey-ai/hebo-gateway/",
+      "linkedin": "https://www.linkedin.com/company/heboai/"
+    }
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-ZJJ115Z0CH"
+    }
+  }
+}

--- a/docs/evals/getting-started.mdx
+++ b/docs/evals/getting-started.mdx
@@ -1,0 +1,340 @@
+---
+title: "Getting Started"
+description: "Markdown for Evals, a human-first format"
+---
+
+## Hebo Eval CLI
+
+Hebo Eval is a powerful command-line tool for evaluating and testing language models. It provides a robust framework for running evaluations against your AI agents and generating detailed reports.
+
+### Installation
+
+```bash
+bun install -g hebo-eval@latest
+```
+
+### Basic Usage
+
+```bash
+hebo-eval run <agent> [options]
+```
+
+### Command Options
+
+| Option                           | Description                                  | Default      |
+| -------------------------------- | -------------------------------------------- | ------------ |
+| `-d, --directory <path>`         | Directory containing test cases              | `./examples` |
+| `-c, --config <path>`            | Path to configuration file                   | -            |
+| `-t, --threshold <number>`       | Score threshold for passing (0-1)            | `0.8`        |
+| `-f, --format <format>`          | Output format (json\|markdown\|text)         | `text`       |
+| `-s, --stop-on-error`            | Stop processing on first error               | `false`      |
+| `-m, --max-concurrency <number>` | Maximum number of concurrent test executions | `5`          |
+| `-v, --verbose`                  | Show detailed output for all test cases      | `false`      |
+
+### Configuration
+
+You can configure Hebo Eval in two ways:
+
+1. **Environment Variables**:
+
+   ```bash
+   export HEBO_API_KEY=your_api_key_here
+   export OPENAI_API_KEY=your_openai_key_here
+   export HEBO_EMBEDDING_API_KEY=your_embedding_key_here
+   ```
+
+2. **Configuration File**:
+   Create a YAML configuration file (e.g., `hebo-evals.config.yaml`):
+
+   ```yaml
+   # Hebo Eval Configuration Template
+   # Copy this file to hebo-evals.config.yaml and replace the values with your own
+
+   # Provider configurations
+   providers:
+     openai:
+       provider: openai
+       baseUrl: https://api.openai.com/v1
+       apiKey: ${OPENAI_API_KEY} # Will be replaced with the value of OPENAI_API_KEY environment variable
+       authHeader:
+         name: Authorization
+         format: Bearer ${OPENAI_API_KEY} # Can use the same environment variable multiple times
+
+     hebo:
+       provider: hebo
+       baseUrl: https://app.hebo.ai
+       apiKey: ${HEBO_API_KEY} # Will be replaced with the value of HEBO_API_KEY environment variable
+       authHeader:
+         name: Authorization
+         format: Bearer ${HEBO_API_KEY}
+
+   # Default provider to use if not specified in the command
+   defaultProvider: hebo
+
+   # Embedding configuration
+   embedding:
+     provider: hebo
+     model: hebo-embeddings
+     baseUrl: https://api.hebo.ai/v1
+     apiKey: ${HEBO_EMBEDDING_API_KEY} # Can reuse the same environment variable
+   ```
+
+   **Note**: The configuration file supports environment variable substitution using `${VARIABLE_NAME}` syntax. This allows you to keep sensitive information like API keys in environment variables while referencing them in your configuration file.
+
+### Configuration Template
+
+Hebo Eval provides a boilerplate configuration template called `hebo-evals.config.yaml`. This template includes:
+
+- **Multiple Provider Support**: Configure both OpenAI and Hebo providers
+- **Environment Variable Integration**: Use `${VARIABLE_NAME}` syntax for secure API key management
+- **Flexible Authentication**: Support for different authentication header formats
+- **Embedding Configuration**: Separate configuration for embedding models
+
+To use the template:
+
+1. Copy the template to your project directory:
+
+   ```bash
+   cp hebo-evals.config.yaml ./your-project/
+   ```
+
+2. Set up your environment variables:
+
+   ```bash
+   export OPENAI_API_KEY=your_openai_key_here
+   export HEBO_API_KEY=your_hebo_key_here
+   export HEBO_EMBEDDING_API_KEY=your_embedding_key_here
+   ```
+
+3. Customize the configuration as needed for your specific use case.
+
+**Security Note**: Never commit your actual configuration file with real API keys to version control. Always use environment variables for sensitive information.
+
+## Provider Mapping Logic
+
+When running Hebo Eval, the provider is automatically determined based on the model or agent name you specify in the command. The tool uses pattern matching to map the model/agent name to the appropriate provider:
+
+- **OpenAI**: Any model name that starts with `gpt-` (e.g., `gpt-3.5-turbo`, `gpt-4`) is mapped to the OpenAI provider.
+- **Hebo**: Any model name that contains a colon (`:`) (e.g., `gato-qa:v1`) is mapped to the Hebo provider.
+- **Anthropic**: Any model name that starts with `claude-` (e.g., `claude-2`, `claude-instant`) is mapped to the Anthropic provider.
+- **Custom**: Any model name that starts with `custom-` is mapped to the Custom provider.
+
+This mapping allows you to simply specify the model or agent name when running evaluations, and Hebo Eval will automatically select the correct provider configuration based on these naming conventions.
+
+**Example:**
+
+```bash
+hebo-eval run gpt-4         # Uses OpenAI provider
+hebo-eval run gato-qa:v1    # Uses Hebo provider
+hebo-eval run claude-2      # Uses Anthropic provider (future support)
+hebo-eval run custom-foo    # Uses Custom provider (future support)
+```
+
+> **Note:**  
+> Currently, Hebo Eval only supports **OpenAI** and **Hebo** as providers. Support for additional providers such as Anthropic and Custom is planned for future releases.
+
+If you need to override the default mapping, you can specify the provider explicitly in your configuration file or command options.
+
+### Test Cases
+
+Hebo Eval supports a flexible test case structure that allows you to organize and manage your test cases effectively.
+
+#### Test Case Structure
+
+1. **Multiple Test Cases in One File**:
+   - Test cases can be defined in a single file, separated by `---`
+   - Each test case starts with a title using `# Test Case Name` format
+
+2. **Directory Organization**:
+   - Test cases can be organized in subdirectories
+   - All test cases in subdirectories are automatically discovered and executed
+
+#### Test Case Format
+
+```text
+# Basic Conversation Test
+user: Hi there!
+assistant: Hello! How can I assist you today?
+
+---
+# Weather Query Test
+user: Could you check the current weather in New York for me?
+assistant: It's rainy in New York today with a temperature of 59°F. There's an 80% chance of rain, high humidity (96%), and a light breeze at 2 mph. You might want to bring an umbrella!
+```
+
+#### Special Characters and Multiline Messages
+
+When writing test cases, it's important to understand how to handle special characters and multiline messages correctly. Here's a comprehensive guide:
+
+#### Special Characters
+
+The following characters have special meaning in test cases:
+
+| Character | Usage                 | Example                          |
+| --------- | --------------------- | -------------------------------- |
+| `:`       | Role marker delimiter | `user:`, `assistant:`, `system:` |
+| `#`       | Test case title       | `# My Test Case`                 |
+| `---`     | Test case separator   | Used between test cases          |
+
+#### Escaping Special Characters
+
+To include literal special characters in your messages, you can use them directly in the message content. The parser will only interpret these characters as special when they appear in specific contexts:
+
+- `:` is only special when it appears after a role marker
+- `#` is only special when it appears at the start of a line
+- `---` is only special when it appears on its own line
+
+Examples:
+
+```text
+# Special Characters Example
+user: The price is $10:50
+assistant: That's correct! The colon (:) is just part of the price.
+
+user: Here's a markdown heading: # Important Note
+assistant: The # symbol is just part of the text here.
+
+user: The separator looks like this: ---
+assistant: Yes, that's just three hyphens in the text.
+```
+
+#### Multiline Message Format
+
+Hebo Eval supports two styles of multiline messages:
+
+1. **Indented Style**:
+
+   ```text
+   user: This is a multiline message
+         that continues on the next line
+         with proper indentation
+   ```
+
+2. **Non-indented Style**:
+   ```text
+   user: This is another multiline message
+   that continues on the next line
+   without indentation
+   ```
+
+Both styles are valid and will be parsed correctly. Choose the style that best fits your needs.
+
+#### Directory Structure Example
+
+```
+tests/
+├── basic/
+│   ├── conversations.txt
+│   └── simple_queries.txt
+├── advanced/
+│   ├── tool_usage.txt
+│   └── complex_scenarios.txt
+└── main.txt
+```
+
+### Output Format
+
+The tool supports three output formats with different verbosity levels:
+
+#### Default Output (Concise)
+
+```
+Passed examples/more tests/test/Silly math
+Passed examples/example/First Test Case
+Passed examples/more tests/test/Math
+Passed examples/math/math
+Passed examples/example/Second Test Case
+Passed examples/example/Third Test Case
+Failed examples/stocks/stocks
+Passed examples/news/news
+Passed examples/translation/translation
+Passed examples/weather/weather
+
+Failed Test Details
+=================
+examples/stocks/stocks
+Status: Failed
+Score: 0.398
+Time: 16694.51ms
+
+Input:
+user: what's the current price of Apple stock?
+assistant: I'll check the current stock price
+Apple's stock (AAPL) is currently trading at USD175.25, up 2.3 percent today
+user: can you write that again in simple terms?
+
+Expected Output:
+assistant: something something someting in simple terms
+
+Actual Response:
+Sure, I can rephrase that in simpler terms:
+
+Apple's shares cost $175.25 each right now. The price went up a bit today.
+
+Error:
+Response mismatch
+
+Test Summary
+============
+Total: 10
+Passed: 9
+Failed: 1
+Duration: 50.54s
+```
+
+### Example Usage
+
+1. **Basic Evaluation**:
+
+   ```bash
+   hebo-eval run gato-qa:v1
+   ```
+
+2. **Custom Directory and Format**:
+
+   ```bash
+   hebo-eval run gato-qa:v1 -d ./my-tests -f markdown
+   ```
+
+3. **With Configuration File**:
+
+   ```bash
+   hebo-eval run gato-qa:v1 -c ./hebo-evals.config.yaml
+   ```
+
+4. **Custom Threshold and Concurrency**:
+
+   ```bash
+   hebo-eval run gato-qa:v1 -t 0.5 -m 10
+   ```
+
+5. **Verbose Output**:
+   ```bash
+   hebo-eval run gato-qa:v1 -v
+   ```
+
+### Best Practices
+
+1. Always set up your API keys using environment variables for security
+2. Use the provided `hebo-evals.config.yaml` template as a starting point
+3. Start with a small test set before running large evaluations
+4. Use descriptive test case titles with the `#` format
+5. Organize test cases in subdirectories for better management
+6. Keep your configuration file secure and never commit API keys to version control
+7. Use the `-v` flag when debugging test failures
+8. Leverage environment variable substitution in your configuration for better security
+
+### Troubleshooting
+
+If you encounter the "HEBO_API_KEY is required" error:
+
+1. Verify your environment variables:
+
+   ```bash
+   export HEBO_API_KEY=your_api_key_here
+   ```
+
+2. Or use a configuration file:
+   ```bash
+   hebo-eval run <agent> --config path/to/hebo-evals.config.yaml
+   ```

--- a/docs/gateway/attachments.mdx
+++ b/docs/gateway/attachments.mdx
@@ -1,0 +1,90 @@
+---
+title: "Attachments"
+description: "Send images, PDFs, Markdown and other files to chat models"
+---
+
+Attachments let you send file inputs (images, audio, PDFs, Markdown, ...) to the Gateway. They can either be embedded as binary data or referenced with an URL.
+
+<Info>
+  Attachment support varies by provider and model version. The Gateway forwards attachments
+  directly to the provider, so unsupported types will return a provider error.
+
+Many modern models support images, video, audio, and PDFs; some also support Office formats
+(e.g., DOCX, PPTX, XLSX). Refer to `/models` and the provider’s official documentation for the
+latest capability details.
+
+</Info>
+
+# From a URL (e.g. Markdown page)
+
+If you have a file hosted on a URL, you can reference it directly in the message. The Vercel AI SDK will download it and then attach the binary to the message.
+
+```ts highlight={20-24}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const { text } = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "How to find out which models are supported by Hebo?",
+        },
+        {
+          type: "file",
+          data: new URL("https://hebo.ai/docs/gateway/supported-models.md"),
+          mediaType: "text/markdown",
+        },
+      ],
+    },
+  ],
+});
+
+console.log(text);
+```
+
+# From local File (e.g. Image)
+
+If you already have a file locally, you can attach the binary data to the model call. Internally, it will automatically be converted to base64.
+
+```ts highlight={3,21-24}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText } from "ai";
+import { readFile } from "node:fs/promises";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const { text } = await generateText({
+  model: hebo("google/gemini-3-flash-preview"),
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Describe this image.",
+        },
+        {
+          type: "image",
+          image: await readFile("<FILENAME>"),
+        },
+      ],
+    },
+  ],
+});
+
+console.log(text);
+```

--- a/docs/gateway/embeddings.mdx
+++ b/docs/gateway/embeddings.mdx
@@ -1,0 +1,26 @@
+---
+title: "Embeddings"
+description: "Generate vector embeddings from text"
+---
+
+You can generate embeddings with the same OpenAI-compatible API across providers.
+
+Common use cases include semantic search, RAG retrieval, clustering, and deduplication.
+
+```ts Vercel AI SDK highlight={9-13}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { embed } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const { embedding } = await embed({
+  model: hebo.embeddingModel("voyage/voyage-3.5"),
+  value: "Tell me a joke about monkeys",
+});
+
+console.log(embedding.length);
+```

--- a/docs/gateway/quick-start.mdx
+++ b/docs/gateway/quick-start.mdx
@@ -1,0 +1,122 @@
+---
+title: "Quick Start"
+description: "Your first ```/chat/completions``` call"
+---
+
+Hebo Gateway provides a unified API for completions, embeddings, and model discovery.
+It normalizes provider differences so you can switch models without rewriting your client.
+
+## Why Gateway
+
+- OpenAI-compatible endpoints and normalized model IDs across providers
+- One way to configure reasoning across all models
+- Support for streaming and non-streaming responses, as well as reasoning and tool calls
+- Compatible with common AI SDKs (Vercel AI SDK, TanStack AI, Langchain, OpenAI SDK, ...)
+
+## Choose an SDK
+
+If you havent installed any SDK yet, you'll have to do that first.
+
+Most of our own examples in the documentation will refer to Vercel AI SDK (which we use ourselves internally) using TypeScript.
+
+<CodeGroup>
+
+```ts Vercel AI SDK
+bun add ai @ai-sdk/openai-compatible
+```
+
+```ts OpenAI SDK
+bun add openai
+```
+
+```ts LangChain
+bun add @langchain/openai
+```
+
+</CodeGroup>
+
+<Info>
+  We recommend ```bun``` as your default JavaScript / TypeScript toolkit, but you can also use
+  ```npm```, ```pnpm``` or ```yarn```.
+</Info>
+
+You can use any other SDKs and languages (e.g. Python), as long as they can connect to an OpenAI-compatible endpoint.
+
+If you find any issues accessing Hebo Gateway with another library, we would appreciate a report on our [issue tracker](https://github.com/heboai/hebo/issues).
+
+## Your First Call
+
+Now you're already ready for your first call:
+
+<CodeGroup>
+
+```ts Vercel AI SDK
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const { text } = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "Tell me a joke about monkeys",
+});
+
+console.log(text);
+```
+
+```ts OpenAI SDK
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const response = await client.chat.completions.create({
+  model: "openai/gpt-oss-20b",
+  messages: [{ role: "user", content: "Tell me a joke about monkeys" }],
+});
+
+console.log(response.choices[0]?.message?.content);
+```
+
+```ts LangChain
+import { ChatOpenAI } from "@langchain/openai";
+
+const model = new ChatOpenAI({
+  apiKey: process.env.HEBO_API_KEY,
+  configuration: { baseURL: "https://gateway.hebo.ai/v1" },
+  model: "openai/gpt-oss-20b",
+});
+
+const response = await model.invoke([{ role: "user", content: "Tell me a joke about monkeys" }]);
+
+console.log(response.content);
+```
+
+```bash Bash
+curl https://gateway.hebo.ai/v1/chat/completions \
+  -H "Authorization: Bearer $HEBO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "messages": [
+      { "role": "user", "content": "Tell me a joke about monkeys" }
+    ]
+  }'
+```
+
+</CodeGroup>
+
+<Info>
+  If you don't have an API key yet, register for free in the [Hebo
+  Console](https://console.hebo.ai).
+</Info>
+
+## What's Next?
+
+- Dig deeper into advanced features like [Tool Calling](/gateway/tool-calling), [Structured Outputs](/gateway/structured-outputs), [Reasoning](/gateway/reasoning), and [Embeddings](/gateway/embeddings).

--- a/docs/gateway/reasoning.mdx
+++ b/docs/gateway/reasoning.mdx
@@ -1,0 +1,169 @@
+---
+title: "Reasoning"
+description: "A standardized a way to configure reasoning across models"
+---
+
+Different providers express reasoning in different ways (token budgets, effort levels, or model-specific flags).
+Hebo Gateway standardizes this into a single `reasoning` configuration so you can keep one client and switch models safely.
+
+## Reasoning Effort
+
+You can pass a normalized `reasoningEffort` parameter with a consistent shape across providers.
+It supports the following values:
+
+| Value     | Meaning                   |
+| --------- | ------------------------- |
+| `none`    | Disable reasoning.        |
+| `minimal` | Lowest reasoning effort.  |
+| `low`     | Low reasoning effort.     |
+| `medium`  | Default reasoning effort. |
+| `high`    | High reasoning effort.    |
+| `xhigh`   | Maximum reasoning effort. |
+
+Hebo automatically maps this setting to the appropriate provider-specific controls (effort tiers, token budgets, or internal flags), so your application code remains unchanged when switching models.
+
+## Basic Example
+
+```ts Vercel AI SDK highlight={13-17,20}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const result = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "Why did the monkey bring a ladder to the bar?",
+  providerOptions: {
+    hebo: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+
+console.log("Reasoning: ", result.reasoningText);
+console.log("Text: ", result.text);
+```
+
+<Info>
+  Some models don't support returning reasoning content, in which case the ```result.reasoning```
+  parameter will be empty. The model still used reasoniong internally.
+</Info>
+
+## Chain-Of-Thoughts
+
+If you use streaming, you can see the thought process of the model in realtime.
+
+```ts Vercel AI SDK highlight={10,21-24}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { streamText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const result = streamText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "Tell me a very long story about monkeys",
+  providerOptions: {
+    hebo: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === "reasoning-delta") {
+    process.stdout.write("<REASONING STEP>\n");
+    process.stdout.write(part.text);
+    process.stdout.write("</REASONING STEP>\n\n");
+  }
+
+  if (part.type === "text-delta") {
+    process.stdout.write(part.text);
+  }
+}
+```
+
+<Info>
+  Not all models provide the detailed chain-of-thoughts output, summ will only provide a reasoning
+  summary at the end.
+</Info>
+
+## Follow-up Calls
+
+Follow-up calls should reuse the previous response messages, so the next request preserves the model’s context, including any tool calls and internal thought process.
+
+Some providers also include reasoning metadata that must be passed along to keep model behavior consistent across a conversation.
+
+Hebo Gateway handles this automatically, as long as you include the full returned messages object in your next request.
+
+```ts
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const messages = [
+  { role: "user", content: "Why did the monkey bring a ladder to the bar?" } as const,
+];
+
+const first = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  messages,
+  providerOptions: {
+    hebo: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+
+console.log(first.text + "\n");
+
+messages.push(...first.response.messages);
+messages.push({
+  role: "user",
+  content: "Why did the monkey bring a ladder to the bar?",
+} as const);
+
+const second = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  messages,
+  providerOptions: {
+    hebo: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+
+console.log(second.text);
+```
+
+Internally, this automatically preserves reasoning details and thought signatures across follow-up calls.
+
+## Advanced Parameters
+
+For more configurability, the normalized `reasoning` object supports the following parameters:
+
+```json
+"reasoning": {
+  "enabled": true,      // turn reasoning on/off
+  "effort": "medium",   // none | minimal | low | medium | high | xhigh
+  "maxTokens": 2048,   // max tokens for reasoning (advanced)
+  "exclude": false      // exclude reasoning from response payload
+}
+```
+
+<Info>
+  Keep in mind, when you tweak the individual parameters that some models might not support your
+  specific settings.
+</Info>

--- a/docs/gateway/streaming.mdx
+++ b/docs/gateway/streaming.mdx
@@ -1,0 +1,27 @@
+---
+title: "Streaming"
+description: "Stream tokens for faster perceived latency"
+---
+
+Streaming lets you deliver tokens as they are generated, so users see output immediately.
+It improves perceived latency, supports long responses without timeouts, and enables realtime UX like typing indicators.
+
+```ts Vercel AI SDK highlight={10,15-17}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { streamText } from "ai";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const result = streamText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "Tell me a very long story about monkeys",
+});
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
+}
+```

--- a/docs/gateway/structured-outputs.mdx
+++ b/docs/gateway/structured-outputs.mdx
@@ -1,0 +1,49 @@
+---
+title: "Structured Outputs"
+description: "Generate typed JSON that follows a schema"
+---
+
+Structured outputs let you force model responses into a predictable JSON shape.
+
+This is useful when you need app-ready data from model output, like extracting fields, choosing the next workflow step, or auto-filling forms without brittle string parsing.
+
+```ts Vercel AI SDK highlight={3,4,12-29}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const RecipeSchema = z.object({
+  name: z.string(),
+  servings: z.number().int().positive(),
+  prepMinutes: z.number().int().nonnegative(),
+  cookMinutes: z.number().int().nonnegative(),
+  ingredients: z.array(
+    z.object({
+      item: z.string(),
+      amount: z.string(),
+    }),
+  ),
+  steps: z.array(z.string()).min(1),
+});
+
+const { output } = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "Create a simple vegetarian pasta recipe for 2 servings.",
+  output: Output.object({
+    schema: RecipeSchema,
+  }),
+});
+
+console.log(output);
+```
+
+<Info>
+  Keep your schemas small and explicit. This improves generation quality and reduces post-processing
+  edge cases.
+</Info>

--- a/docs/gateway/supported-models.mdx
+++ b/docs/gateway/supported-models.mdx
@@ -1,0 +1,12 @@
+---
+title: "Models"
+description: "List all models available on Hebo Gateway"
+---
+
+Simply call the `/models` endpoint:
+
+```bash Bash
+curl https://gateway.hebo.ai/v1/models
+```
+
+<Info>This endpoint does not require authentication</Info>

--- a/docs/gateway/tool-calling.mdx
+++ b/docs/gateway/tool-calling.mdx
@@ -1,0 +1,48 @@
+---
+title: "Tool Calling"
+description: "Provide your agent with additional capabilities"
+---
+
+Tool calling lets models invoke deterministic functions for things they’re bad at: counting, lookups, validation, and calling external systems. It makes responses more reliable and lets you combine LLM reasoning with real-world actions.
+
+## Local
+
+By default, the LLM only suggests a tool call; the actual execution runs in your own agent code and returns the result.
+
+```ts Vercel AI SDK highlight={14-25}
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { generateText, tool } from "ai";
+import { z } from "zod";
+
+const hebo = createOpenAICompatible({
+  name: "hebo",
+  apiKey: process.env.HEBO_API_KEY,
+  baseURL: "https://gateway.hebo.ai/v1",
+});
+
+const result = await generateText({
+  model: hebo("openai/gpt-oss-20b"),
+  prompt: "How many r's are in Strawberry?",
+  tools: {
+    countLetters: tool({
+      description: "Count letter occurrences in a word",
+      inputSchema: z.object({
+        word: z.string(),
+        letters: z.string(),
+      }),
+      execute: async ({ word, letters }) => {
+        const count = [...word].filter((c) => letters.includes(c)).length;
+        return { count };
+      },
+    }),
+  },
+});
+
+console.log(result.toolResults[0]?.output);
+```
+
+## MCP
+
+MCP (Model Context Protocol) is a standard way to expose tools over a remote server.
+
+For read-to-use MCP tools, see the our [MCP AIKit](/mcp/aikit) docs.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,51 @@
+---
+title: "Introduction"
+description: "The AI platform for cross-functional teams"
+---
+
+# Hebo AI
+
+## Introduction
+
+Building production-ready conversational agents requires fast iteration across engineering, product, and business teams. In practice, iteration is slow, even small changes often require code updates and lengthy re-deployments.
+
+Hebo addresses this by providing a shared platform for building, operating, and improving AI agents:
+
+- A gateway with standardized OpenAI-compatible API across LLMs
+- Composable primitives for RAG, tools, and memory
+- Built-in observability & evaluations focused on real conversation flows
+
+Wrapped into a simple user interface for operational teams to define agent behavior, observe conversations and optimize knowledge.
+
+Every component is opt-in and designed to scale with agent complexity, from simple prompts to production systems.
+
+## Component Status
+
+- **Gateway**: v0.1 (live)
+- **MCP AIKit**: v0.1 (live)
+- **Evals**: v0.1 (live)
+- **RAG / Tools / Memory stack**: WIP
+- **Observability**: WIP
+- **Knowledge Editor**: WIP
+
+## Getting Started
+
+1. **Register your Account**: Visit [console.hebo.ai](https://console.hebo.ai) to create an account.
+2. **Create an Agent**: The on-boarding flow will guide you through creating an agent and selecting a default model.
+3. **Execute API Calls**: Use your API keys to interact with your agents programmatically.
+
+## Support
+
+Join us on Discord for support and discussions: [Discord Channel](https://discord.gg/cCJtXZRU5p)
+
+## Contributing
+
+Hebo is built in the open with an [Open-Source license](https://fsl.software/) that keeps Hebo **free to use for everyone** while discouraging harmful free-riding.
+
+We’re still at the very beginning and welcome contributions from the community. To get started:
+
+1. Open an issue from our [issue tracker](https://github.com/heboai/hebo/issues).
+2. Open a [pull request](https://github.com/8monkey-ai/hebo/pulls) with your proposed changes.
+3. Ping us on our [discord channel](https://discord.gg/cCJtXZRU5p).
+
+We look forward to your contributions!

--- a/docs/mcp/aikit.mdx
+++ b/docs/mcp/aikit.mdx
@@ -1,0 +1,51 @@
+---
+title: "AIKit Tools"
+description: "A collection of pre-hosted MCP tools"
+---
+
+Hebo AIKit is a set of ready-to-use MCP toolkits hosted at `https://mcp.hebo.ai/`.
+
+It lets you connect tools to any LLM quickly without standing up your own server.
+
+## Highlights
+
+- Pre-hosted MCP server with real tools you can use immediately
+- Built to cover tasks agents struggle with like counting
+- Simple integration with the Vercel AI SDK and other clients
+- Transparent tool schemas so agents can decide when to call them
+- New toolkits added over time (request more on Discord)
+
+## Why it exists
+
+Most MCP examples are low-level and require self-hosting just to test.
+AIKit removes the infrastructure setup so you can validate MCP end-to-end in minutes.
+
+## Sample Usage
+
+```ts Vercel AI SDK
+import { streamText } from "ai";
+import { createMCPClient } from "@ai-sdk/mcp";
+
+const mcpClient = await createMCPClient({
+  transport: {
+    type: "http",
+    url: "https://mcp.hebo.ai/aikit/",
+  },
+});
+
+const { count_letters } = await mcpClient.tools();
+
+const result = await streamText({
+  model: "openai/gpt-oss-20b",
+  tools: { count_letters },
+  prompt: "How many r's in Strawberry?",
+  onFinish: async () => {
+    await mcpClient.close();
+  },
+});
+```
+
+<Note>
+  You can use any provider supported by the Vercel AI SDK, including [Hebo
+  Gateway](/gateway/quick-start).
+</Note>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,19 @@
+html:not(.dark) span.fixed.inset-0 {
+  /* background-color: #f1f5f9; */
+  background:
+    linear-gradient(0deg, oklch(0.985 0.03 100) 0%, oklch(0.975 0.005 240) 60%) 0 0 / 100% 100vh
+      no-repeat,
+    oklch(0.985 0.03 100);
+}
+
+html:not(.dark) #sidebar {
+  background-color: #f1f5f9;
+}
+
+#sidebar-title {
+  font-weight: bold;
+}
+
+.nav-anchor {
+  font-weight: semibold !important;
+}


### PR DESCRIPTION
Moves the Mintlify documentation folder from `hebo-www` into `hebo-platform` so AI agents can update docs alongside the platform code.

Closes #393

Generated with [Claude Code](https://claude.ai/code)