### PR TITLE
Fix preview cleanup stage detection

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Remove preview environment
         run: |
           STAGE="pr-${{ github.event.pull_request.number }}"
-          if ! bun run sst list --stage $STAGE; then
+          if ! bun run sst state list | grep -q "${STAGE}"; then
             echo "Stage $STAGE does not exist, skipping cleanup"
             exit 0
           fi


### PR DESCRIPTION
## Summary

- Replace non-existent `sst list --stage $STAGE` with `sst state list | grep -q "${STAGE}"` in the preview cleanup workflow

## Problem

The `preview-cleanup.yml` workflow used `bun run sst list --stage $STAGE` to check whether a preview stage exists before running `sst remove`. However, `sst list` is not a valid SST CLI command (neither in v3 nor v4), so the guard always failed and cleanup was silently skipped.

## Fix

`sst state list` outputs all deployed stages (one per line, indented). Piping through `grep -q` checks whether the target stage name appears in the output. If it doesn't, cleanup is skipped gracefully; if it does, `sst remove` proceeds as intended.

## Test plan

- [x] Verified `bun run sst state list` output format locally
- [x] Confirmed `grep -q "pr-398"` matches correctly against the output

Made with [Cursor](https://cursor.com)