### PR TITLE
downgrade 4xx log severity from error to warn

### DIFF
--- a/packages/shared-api/middlewares/logging.ts
+++ b/packages/shared-api/middlewares/logging.ts
@@ -24,13 +24,9 @@ export const logging = (serviceName?: string) => {
   }
 
   app.onError(function logRequestError({ error, set }) {
-    logger.error(
-      {
-        status: typeof set.status === "number" ? set.status : 500,
-        err: error,
-      },
-      "request:error",
-    );
+    const status = typeof set.status === "number" ? set.status : 500;
+    const log = status >= 500 ? logger.error : logger.warn;
+    log.call(logger, { status, err: error }, "request:error");
   });
 
   return app.as("scoped");


### PR DESCRIPTION
Split the onError handler so client errors (4xx) log at warn level while server errors (5xx) continue to log at error level. This reduces alert noise from non-actionable client-side issues.

Closes #403

Generated with [Claude Code](https://claude.ai/code)