### PR TITLE
use http.response.status_code for traces status filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ ElysiaJS powers `apps/api` and `apps/gateway`; call helpers from `packages/share
 
 Since we are using React Compiler, don't use useMemo, useCallback, and React.memo.
 
+Bun.sql returns `bigint` columns as strings, not numbers. Always parse these string values to numbers before performing arithmetic or numeric comparisons (e.g., HTTP status codes stored as bigint).
+
 ## Console Frontend Patterns
 
 ### Search Params as State

--- a/apps/api/src/modules/traces/service.ts
+++ b/apps/api/src/modules/traces/service.ts
@@ -85,11 +85,12 @@ export async function listTraces(
     metaFilterSql += ` AND "${escapeSqlIdentifier(`${METADATA_PREFIX}${key}`)}" = ${addParam(value)}`;
   }
 
+  const HTTP_STATUS_COL = '"span_attributes.http.response.status_code"';
   let statusFilterSql = "";
   if (statusFilter === "ok") {
-    statusFilterSql = ` AND "span_status_code" IN ('STATUS_CODE_OK', 'STATUS_CODE_UNSET')`;
+    statusFilterSql = ` AND (${HTTP_STATUS_COL} IS NOT NULL AND ${HTTP_STATUS_COL} < 400)`;
   } else if (statusFilter === "error") {
-    statusFilterSql = ` AND "span_status_code" = 'STATUS_CODE_ERROR'`;
+    statusFilterSql = ` AND (${HTTP_STATUS_COL} IS NULL OR ${HTTP_STATUS_COL} >= 400)`;
   }
 
   let operationFilterSql = "";
@@ -105,7 +106,7 @@ export async function listTraces(
     SELECT
       "timestamp" AS timestamp,
       "trace_id" AS trace_id,
-      "span_status_code" AS span_status_code,
+      "span_attributes.http.response.status_code" AS http_status_code,
       "span_status_message" AS span_status_message,
       "duration_nano" AS duration_nano,
       "span_attributes.gen_ai.operation.name" AS operation_name,
@@ -145,7 +146,7 @@ export async function listTraces(
       operationName: parseString(row.operation_name),
       model: parseString(row.response_model),
       provider: parseString(row.provider_name),
-      status: formatStatus(row.span_status_code),
+      status: formatStatus(row.http_status_code),
       statusMessage: parseString(row.span_status_message),
       durationMs: Number(row.duration_nano) / 1e6,
       summary: extractLastUserSummary(row.input_messages),
@@ -183,7 +184,7 @@ export async function getSpans(
     SELECT
       "timestamp" AS timestamp,
       "span_id" AS span_id,
-      "span_status_code" AS span_status_code,
+      "span_attributes.http.response.status_code" AS http_status_code,
       "span_status_message" AS span_status_message,
       "duration_nano" AS duration_nano,
       "span_attributes.gen_ai.operation.name" AS operation_name,
@@ -242,7 +243,7 @@ export async function getSpans(
       model: parseString(row.request_model),
       responseModel: parseString(row.response_model),
       provider: parseString(row.provider_name),
-      status: formatStatus(row.span_status_code),
+      status: formatStatus(row.http_status_code),
       statusMessage: parseString(row.span_status_message),
       durationMs: Number(row.duration_nano ?? 0) / 1e6,
       inputTokens: parseNullableNumber(row.input_tokens),

--- a/apps/api/src/modules/traces/service.ts
+++ b/apps/api/src/modules/traces/service.ts
@@ -85,7 +85,7 @@ export async function listTraces(
     metaFilterSql += ` AND "${escapeSqlIdentifier(`${METADATA_PREFIX}${key}`)}" = ${addParam(value)}`;
   }
 
-  const HTTP_STATUS_COL = '"span_attributes.http.response.status_code"';
+  const HTTP_STATUS_COL = '"span_attributes.http.response.status_code_effective"';
   let statusFilterSql = "";
   if (statusFilter === "ok") {
     statusFilterSql = ` AND (${HTTP_STATUS_COL} IS NOT NULL AND ${HTTP_STATUS_COL} < 400)`;
@@ -106,7 +106,7 @@ export async function listTraces(
     SELECT
       "timestamp" AS timestamp,
       "trace_id" AS trace_id,
-      "span_attributes.http.response.status_code" AS http_status_code,
+      "span_attributes.http.response.status_code_effective" AS http_status_code,
       "span_status_message" AS span_status_message,
       "duration_nano" AS duration_nano,
       "span_attributes.gen_ai.operation.name" AS operation_name,
@@ -184,7 +184,7 @@ export async function getSpans(
     SELECT
       "timestamp" AS timestamp,
       "span_id" AS span_id,
-      "span_attributes.http.response.status_code" AS http_status_code,
+      "span_attributes.http.response.status_code_effective" AS http_status_code,
       "span_status_message" AS span_status_message,
       "duration_nano" AS duration_nano,
       "span_attributes.gen_ai.operation.name" AS operation_name,

--- a/apps/api/src/modules/traces/utils.ts
+++ b/apps/api/src/modules/traces/utils.ts
@@ -37,10 +37,12 @@ export function parseJsonArray(value: unknown): unknown[] | null {
   return value.map((item) => parseJson(item));
 }
 
-export function formatStatus(statusCode: unknown): "ok" | "error" | "unknown" {
-  if (statusCode === "STATUS_CODE_OK" || statusCode === "STATUS_CODE_UNSET") return "ok";
-  if (statusCode === "STATUS_CODE_ERROR") return "error";
-  return "unknown";
+export function formatStatus(httpStatusCode: unknown): "ok" | "error" | "unknown" {
+  const code = typeof httpStatusCode === "string" ? Number(httpStatusCode) : httpStatusCode;
+  if (typeof code === "number" && Number.isFinite(code)) {
+    return code >= 400 ? "error" : "ok";
+  }
+  return "error";
 }
 
 function truncateSummary(value: string): string {


### PR DESCRIPTION
Use `http.response.status_code` instead of `span_status_code` for traces status filtering and formatting. Bun returns bigint columns as strings, so `formatStatus` parses the string to a number before comparison. NULL HTTP status (no response) is treated as error consistently.

Closes #406

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on handling database bigint values that are returned as strings, including instructions for parsing these values before performing arithmetic or numeric comparisons.

* **Bug Fixes**
  * Updated trace status filtering to use HTTP response status codes for improved accuracy in status classification, with "ok" for successful responses and "error" for failed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->