### PR TITLE
fix: use inline routes for gateway router to avoid CF 502

### DIFF
--- a/infra/stacks/api.ts
+++ b/infra/stacks/api.ts
@@ -51,8 +51,8 @@ const heboApi = new sst.aws.Service("HeboApi", {
 createMigrator("api");
 
 export const apiRouter = new sst.aws.Router("HeboApiRouter", {
-  routes: { "/*": heboApi.url },
   domain: hostname("api"),
 });
+apiRouter.route("/", heboApi.url);
 
 export default heboApi;

--- a/infra/stacks/auth.ts
+++ b/infra/stacks/auth.ts
@@ -47,8 +47,8 @@ const heboAuth = new sst.aws.Service("HeboAuth", {
 createMigrator("auth");
 
 export const authRouter = new sst.aws.Router("HeboAuthRouter", {
-  routes: { "/*": heboAuth.url },
   domain: hostname("auth"),
 });
+authRouter.route("/", heboAuth.url);
 
 export default heboAuth;

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -79,20 +79,8 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
 });
 
 export const gatewayRouter = new sst.aws.Router("HeboGatewayRouter", {
-  routes: { "/*": heboGateway.url },
   domain: hostname("gateway"),
-  transform: {
-    cdn: (args) => {
-      args.origins = $util.output(args.origins).apply((origins) =>
-        origins!.map((o) => ({
-          ...o,
-          customOriginConfig: o.customOriginConfig
-            ? { ...o.customOriginConfig, originReadTimeout: 60 }
-            : o.customOriginConfig,
-        })),
-      );
-    },
-  },
 });
+gatewayRouter.route("/", heboGateway.url, { readTimeout: "60 seconds" });
 
 export default heboGateway;

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -79,8 +79,20 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
 });
 
 export const gatewayRouter = new sst.aws.Router("HeboGatewayRouter", {
+  routes: { "/*": heboGateway.url },
   domain: hostname("gateway"),
+  transform: {
+    cdn: (args) => {
+      args.origins = $util.output(args.origins).apply((origins) =>
+        origins!.map((o) => ({
+          ...o,
+          customOriginConfig: o.customOriginConfig
+            ? { ...o.customOriginConfig, originReadTimeout: 60 }
+            : o.customOriginConfig,
+        })),
+      );
+    },
+  },
 });
-gatewayRouter.route("/*", heboGateway.url, { readTimeout: "60 seconds" });
 
 export default heboGateway;

--- a/infra/stacks/mcp.ts
+++ b/infra/stacks/mcp.ts
@@ -42,8 +42,8 @@ const heboMcp = new sst.aws.Service("HeboMcp", {
 });
 
 const mcpRouter = new sst.aws.Router("HeboMcpRouter", {
-  routes: { "/*": heboMcp.url },
   domain: hostname("mcp"),
 });
+mcpRouter.route("/", heboMcp.url);
 
 export default heboMcp;


### PR DESCRIPTION
## Summary

Fix Gateway returning 502 "Failed to contact the origin" when accessed through CloudFront.

## Problem

We recently added CloudFront in front of our four services (API, Auth, Gateway, MCP). After deployment, three services worked correctly — but every request to the Gateway through CloudFront returned 502 "Failed to contact the origin", making the Gateway fully unreachable to clients. The Gateway's ALB was healthy the entire time; the issue was in how CloudFront connected to it.

## Cause

SST's `Router` component offers two ways to define where CloudFront should route traffic:

| Approach | How it works | Origin protocol |
|----------|-------------|----------------|
| **Inline `routes`** | Origin is configured directly on the CloudFront distribution | `https-only` |
| **`.route()` method** | Origin is resolved dynamically at request time via a CloudFront Function | Default origin is `http-only` |

API, Auth, and MCP used inline `routes`. Gateway used `.route()` because it needed a custom `readTimeout` (60s), which is only exposed by `.route()`.

With `.route()`, CloudFront's distribution is configured with a placeholder origin using `http-only`. A CloudFront Function is supposed to override this to the real origin with HTTPS at runtime — but in practice, this results in a 502. We confirmed this by deploying twice with `.route()` (502 both times) and then switching to inline `routes` (works immediately).

## Fix

Switch Gateway to inline `routes` and use a `transform.cdn` to set the 60s read timeout, since inline routes don't expose that option directly.

## Verification

```bash
# Gateway reachable through CloudFront
curl -s -o /dev/null -w "%{http_code}" https://gateway.hebo.ai/
# Output: 200

# Origin read timeout correctly set to 60s
aws cloudfront get-distribution-config --id E2KRPOLJY9WT7 \
  --query "DistributionConfig.Origins.Items[0].CustomOriginConfig.OriginReadTimeout" \
  --output text
# Output: 60
```

- [x] All services (api, auth, gateway, mcp, console) returning HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway routing configuration to target only the root path instead of all paths, while maintaining existing timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->