### PR TITLE
fix: disable better-auth global rate limit

### DIFF
--- a/apps/auth/src/better-auth.ts
+++ b/apps/auth/src/better-auth.ts
@@ -82,6 +82,9 @@ export const auth = betterAuth({
   session: {
     cookieCache: { enabled: true },
   },
+  rateLimit: {
+    enabled: false,
+  },
   trustedOrigins: ROOT_DOMAIN ? [`https://*.${ROOT_DOMAIN}`] : ["*"],
   advanced: {
     ...COOKIE_CONFIG.advanced,


### PR DESCRIPTION
Disable better-auth's built-in global rate limiter. Rate limiting is handled at the WAF level (in the future), so the built-in limiter is unnecessary and causes transient 429s on internal service-to-service calls during traffic bursts.

Closes #426

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled top-level rate limiting in authentication service configuration. Plugin-level API key rate limiting behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->