### PR TITLE
fix: rethrow upstream auth errors instead of swallowing as 401

### DIFF
--- a/packages/shared-api/middlewares/auth.ts
+++ b/packages/shared-api/middlewares/auth.ts
@@ -87,7 +87,6 @@ export const auth = new Elysia({ name: "auth-service" })
       });
 
       if (verifyError) {
-        logger.warn({ error: verifyError }, "API key verification request failed");
         throw new HttpError(verifyError.message ?? "Auth service error", verifyError.status ?? 500, "upstream_auth_error");
       }
 

--- a/packages/shared-api/middlewares/auth.ts
+++ b/packages/shared-api/middlewares/auth.ts
@@ -7,7 +7,7 @@ import { type Cookie, Elysia } from "elysia";
 import type { VerifyApiKeyPlugin } from "~auth/lib/api-key";
 
 import { AUTH_SECRET, AUTH_URL } from "../env";
-import { AuthError, BadRequestError } from "../errors";
+import { AuthError, BadRequestError, HttpError } from "../errors";
 import { COOKIE_CONFIG } from "../lib/better-auth";
 import { logging } from "./logging";
 
@@ -88,6 +88,7 @@ export const auth = new Elysia({ name: "auth-service" })
 
       if (verifyError) {
         logger.warn({ error: verifyError }, "API key verification request failed");
+        throw new HttpError(verifyError.message ?? "Auth service error", verifyError.status ?? 500, "upstream_auth_error");
       }
 
       if (result?.valid && result.key) {


### PR DESCRIPTION
When `verifyApiKey` returns any error (429, 5xx, etc.), throw an `HttpError` with the original status code instead of falling through to the 401 path.

Closes #427

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key verification failures now properly return HTTP error responses to clients instead of being silently logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->