### PR TITLE
fix: switch auth service from .mount() to .all() for OTEL instrumentation

### DIFF
--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -19,7 +19,7 @@ const createAuth = () =>
     .use(logging(getLogger("hebo-auth")))
     .get("/", () => "🐵 Hebo Auth says hello!")
     .use(cors(CORS_CONFIG))
-    .mount(auth.handler);
+    .all("/v1/*", ({ request }) => auth.handler(request));
 
 if (import.meta.main) {
   serve(createAuth, PORT, "Hebo Auth", { workers: WORKERS });


### PR DESCRIPTION
Replaces `.mount(auth.handler)` with `.all("/v1/*", ...)` so that requests to better-auth go through Elysia's normal lifecycle. This ensures the OpenTelemetry plugin instruments all responses — including rate limiter 429 rejections that were previously invisible because `.mount()` bypasses Elysia's trace/wrap hooks.

Closes #428

Generated with [Claude Code](https://claude.ai/code)