### PR TITLE
chore: upgrade @msw/data to 1.1.3 and simplify mock workarounds

### DIFF
--- a/apps/console/app/mocks/middleware/chaos.ts
+++ b/apps/console/app/mocks/middleware/chaos.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse, type HttpHandler, type HttpResponseResolver } from "msw";
 
-const CHAOS_NETWORK_RATE = Number(import.meta.env.VITE_CHAOS_NETWORK ?? 0.1);
-const CHAOS_HTTP_RATE = Number(import.meta.env.VITE_CHAOS_HTTP ?? 0.2);
+const CHAOS_NETWORK_RATE = Number(import.meta.env.VITE_CHAOS_NETWORK ?? 0);
+const CHAOS_HTTP_RATE = Number(import.meta.env.VITE_CHAOS_HTTP ?? 0);
 
 const chaosResolver: HttpResponseResolver = (info) => {
   if (info.request.headers.get("x-no-chaos") === "1") return;

--- a/apps/console/app/mocks/middleware/delays.ts
+++ b/apps/console/app/mocks/middleware/delays.ts
@@ -1,10 +1,10 @@
 import { delay, http, type HttpHandler } from "msw";
 
 const METHOD_DELAYS: Partial<Record<keyof typeof http, number>> = {
-  get: 1000,
-  post: 2000,
+  get: 500,
+  post: 1000,
   patch: 1500,
-  delete: 500,
+  delete: 750,
 };
 
 export function addDelays(handlers: HttpHandler[]): HttpHandler[] {

--- a/apps/console/app/mocks/routes/branches.ts
+++ b/apps/console/app/mocks/routes/branches.ts
@@ -30,13 +30,10 @@ export const branchHandlers = [
         models: structuredClone(sourceBranch!.models),
       });
 
-      // FUTURE: Update doesn't work right now in msw/data v1
-      // https://github.com/mswjs/data/issues/346
-      db.agents.delete((q) => q.where({ slug: params.agentSlug }));
-      await db.agents.create({
-        slug: agent!.slug,
-        name: agent!.name,
-        branches: [...agent!.branches, newBranch],
+      await db.agents.update(agent!, {
+        data(a) {
+          a.branches.push(newBranch);
+        },
       });
 
       return HttpResponse.json(newBranch, { status: 201 });

--- a/apps/console/app/mocks/routes/branches.ts
+++ b/apps/console/app/mocks/routes/branches.ts
@@ -9,13 +9,13 @@ export const branchHandlers = [
     async ({ request, params }) => {
       const body = (await request.json()) as {
         name: string;
-        sourceBranchSlug: string;
+        source_branch_slug: string;
       };
       const branchSlug = slugify(body.name, { lower: true, strict: true });
 
       const agent = db.agents.findFirst((q) => q.where({ slug: params.agentSlug }));
 
-      const sourceBranch = agent!.branches.find((b) => b.slug === body.sourceBranchSlug);
+      const sourceBranch = agent!.branches.find((b) => b.slug === body.source_branch_slug);
 
       const existingBranch = agent!.branches.find((b) => b.slug === branchSlug);
       if (existingBranch)

--- a/apps/console/app/mocks/routes/providers.ts
+++ b/apps/console/app/mocks/routes/providers.ts
@@ -27,19 +27,13 @@ export const providerHandlers = [
     const body = await request.json();
     const o = ProviderSchema.options.find((option) => option.shape.slug.value === params.slug);
 
-    const existing = db.providers.findFirst((q) => q.where({ slug: params.slug }));
+    db.providers.delete((q) => q.where({ slug: params.slug }));
 
-    const provider = existing
-      ? await db.providers.update(existing, {
-          data(p) {
-            p.config = body;
-          },
-        })
-      : await db.providers.create({
-          slug: params.slug,
-          name: o!.shape.name.value,
-          config: body,
-        });
+    const provider = await db.providers.create({
+      slug: params.slug,
+      name: o!.shape.name.value,
+      config: body,
+    });
 
     return HttpResponse.json(provider, { status: 201 });
   }),

--- a/apps/console/app/mocks/routes/providers.ts
+++ b/apps/console/app/mocks/routes/providers.ts
@@ -27,13 +27,19 @@ export const providerHandlers = [
     const body = await request.json();
     const o = ProviderSchema.options.find((option) => option.shape.slug.value === params.slug);
 
-    db.providers.delete((q) => q.where({ slug: params.slug }));
+    const existing = db.providers.findFirst((q) => q.where({ slug: params.slug }));
 
-    const provider = await db.providers.create({
-      slug: params.slug,
-      name: o!.shape.name.value,
-      config: body,
-    });
+    const provider = existing
+      ? await db.providers.update(existing, {
+          data(p) {
+            p.config = body;
+          },
+        })
+      : await db.providers.create({
+          slug: params.slug,
+          name: o!.shape.name.value,
+          config: body,
+        });
 
     return HttpResponse.json(provider, { status: 201 });
   }),

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -47,7 +47,7 @@
     "@hebo/typescript-config": "workspace:*",
     "@mdx-js/react": "^3.1.1",
     "@mdx-js/rollup": "^3.1.1",
-    "@msw/data": "^1.1.2",
+    "@msw/data": "^1.1.3",
     "@react-router/dev": "catalog:",
     "@shikijs/rehype": "^3.21.0",
     "@tailwindcss/vite": "^4.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,7 @@
         "@hebo/typescript-config": "workspace:*",
         "@mdx-js/react": "^3.1.1",
         "@mdx-js/rollup": "^3.1.1",
-        "@msw/data": "^1.1.2",
+        "@msw/data": "^1.1.3",
         "@react-router/dev": "catalog:",
         "@shikijs/rehype": "^3.21.0",
         "@tailwindcss/vite": "^4.2.2",
@@ -645,7 +645,7 @@
 
     "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.13.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw=="],
 
-    "@msw/data": ["@msw/data@1.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "es-toolkit": "^1.39.10", "mutative": "^1.3.0", "outvariant": "^1.4.3", "rettime": "^0.7.0" } }, "sha512-beEM1cfb59FdoSV9pmWI+Vllf+QxoYtIDiVE9b1awVAWTa9eeDIZAi1qispBuSSnzZam6lIljCFPYJbXOwEbvA=="],
+    "@msw/data": ["@msw/data@1.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "es-toolkit": "^1.45.1", "mutative": "^1.3.0", "outvariant": "^1.4.3", "rettime": "^0.11.8" } }, "sha512-aqezecY8vvueOSMz8v19ZWpoM0Ei2VuuWt/MZuZ8NBvO2oJvZi5y8PGP6PVutuONu7ms0Or/Am4Rs6Ks9sfg7w=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
@@ -2511,7 +2511,7 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
-    "rettime": ["rettime@0.7.0", "", {}, "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw=="],
+    "rettime": ["rettime@0.11.8", "", {}, "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 


### PR DESCRIPTION
Upgrade `@msw/data` from 1.1.2 to 1.1.3 and replace delete-then-recreate workarounds with proper `update()` calls, now that mswjs/data#346 is fixed.

Also fixes some left-overs from previous refactoring around the source_branch_slug parameter and adjusts some variables to make it easier to use the mock environment.

Closes #432

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API request field naming convention for the branch creation endpoint.
  * Fixed default chaos injection behavior to prevent generating unintended errors when environment variables are missing.

* **Performance**
  * Optimized HTTP method request delay durations for improved response times.

* **Chores**
  * Updated mock service worker dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->