### PR TITLE
fix: metadata filter on traces returns empty results

### DIFF
--- a/apps/api/src/modules/traces/index.ts
+++ b/apps/api/src/modules/traces/index.ts
@@ -1,8 +1,6 @@
 import { Elysia, status } from "elysia";
 import { z } from "zod";
 
-import { BadRequestError } from "@hebo/shared-api/errors";
-
 import { greptime } from "~api/middlewares/greptime";
 
 import { getSpans, listTraces } from "./service";
@@ -18,23 +16,6 @@ export const spansModule = new Elysia({
   .get(
     "/",
     async ({ greptimeDb, organizationId, params, query }) => {
-      let metadata: Record<string, string> = {};
-      if (query.metadata) {
-        try {
-          const parsed: unknown = JSON.parse(query.metadata);
-          if (
-            !parsed ||
-            typeof parsed !== "object" ||
-            Array.isArray(parsed) ||
-            Object.values(parsed).some((value) => typeof value !== "string")
-          )
-            throw new Error("Invalid metadata");
-          metadata = parsed as Record<string, string>;
-        } catch {
-          throw new BadRequestError(`Invalid metadata filter: ${query.metadata}`);
-        }
-      }
-
       return status(
         200,
         await listTraces(
@@ -48,7 +29,7 @@ export const spansModule = new Elysia({
           // https://github.com/elysiajs/elysia/issues/817
           query.page!,
           query.pageSize!,
-          metadata,
+          query.metadata ?? {},
           query.status,
           query.operation,
         ),

--- a/apps/api/src/modules/traces/types.ts
+++ b/apps/api/src/modules/traces/types.ts
@@ -6,7 +6,7 @@ const TraceTimeRangeQuerySchema = {
 };
 
 export const TraceListQuerySchema = z.object({
-  metadata: z.string().optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
   status: z.union([z.literal("ok"), z.literal("error")]).optional(),
   operation: z.union([z.literal("chat"), z.literal("embeddings")]).optional(),
   ...TraceTimeRangeQuerySchema,

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/route.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces/route.tsx
@@ -25,7 +25,7 @@ export async function clientLoader({
         page: page,
         from: effectiveFrom,
         to: effectiveTo,
-        metadata: Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : undefined,
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
         status,
         operation,
       },


### PR DESCRIPTION
## Summary

Fixes the metadata filter on the observability dashboard returning empty results for every metadata key.

## Root cause

After #362, the `/traces` endpoint returns 422 on any metadata filter request because the `metadata` query param arrives already parsed as an object, but the schema declares it as `z.string()` (`expected string, received object`). The console falls back to `listResult.data?.data ?? []` → "No traces found".

## Changes

- **`types.ts`**: Change `metadata` schema from `z.string()` to `z.record(z.string(), z.string())`
- **`index.ts`**: Remove the now-redundant manual `JSON.parse` block and pass `query.metadata ?? {}` directly
- **`route.tsx`**: Pass the metadata record directly instead of `JSON.stringify`-ing it

## Test plan

- [x] Reproduced locally against GreptimeDB: confirmed 422 before the fix, correct filtered results after
- [x] `bun run typecheck` passes (0 errors across all workspaces)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)