### PR TITLE
Skip console build in ECS Docker images

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -28,7 +28,8 @@ COPY --parents package.json bun.lock \
 RUN bun install --frozen-lockfile
 
 COPY . .
-RUN bun run build
+ARG BUILD_SCRIPT=build
+RUN bun run $BUILD_SCRIPT
 
 ########################  tools  ########################
 FROM debian:bookworm-slim AS tools
@@ -70,7 +71,7 @@ COPY --from=builder /repo/apps/gateway/dist          /app/gateway/
 COPY --from=builder /repo/apps/mcp/dist              /app/mcp/
 
 # Console
-COPY --from=builder /repo/apps/console/build/client  /app/console/build/client
+COPY --from=builder /repo/apps/console/build*        /app/console/build/
 COPY --from=builder /repo/apps/console/serve.ts      /app/console/serve.ts
 
 # s6 scripts (classic layout — chmod applied directly, no tools detour)

--- a/infra/stacks/api.ts
+++ b/infra/stacks/api.ts
@@ -20,7 +20,7 @@ const heboApi = new sst.aws.Service("HeboApi", {
     context: ".",
     dockerfile: "infra/docker/Dockerfile",
     tags: [hostname("api")],
-    args: { NODE_ENV: isProduction ? "production" : "development" },
+    args: { NODE_ENV: isProduction ? "production" : "development", BUILD_SCRIPT: "build:ecs" },
   },
   environment: {
     HEBO_MODE: "api",

--- a/infra/stacks/auth.ts
+++ b/infra/stacks/auth.ts
@@ -18,7 +18,7 @@ const heboAuth = new sst.aws.Service("HeboAuth", {
     context: ".",
     dockerfile: "infra/docker/Dockerfile",
     tags: [hostname("auth")],
-    args: { NODE_ENV: isProduction ? "production" : "development" },
+    args: { NODE_ENV: isProduction ? "production" : "development", BUILD_SCRIPT: "build:ecs" },
   },
   environment: {
     HEBO_MODE: "auth",

--- a/infra/stacks/gateway.ts
+++ b/infra/stacks/gateway.ts
@@ -42,7 +42,7 @@ const heboGateway = new sst.aws.Service("HeboGateway", {
     context: ".",
     dockerfile: "infra/docker/Dockerfile",
     tags: [hostname("gateway")],
-    args: { NODE_ENV: isProduction ? "production" : "development" },
+    args: { NODE_ENV: isProduction ? "production" : "development", BUILD_SCRIPT: "build:ecs" },
   },
   environment: {
     HEBO_MODE: "gateway",

--- a/infra/stacks/mcp.ts
+++ b/infra/stacks/mcp.ts
@@ -17,7 +17,7 @@ const heboMcp = new sst.aws.Service("HeboMcp", {
     context: ".",
     dockerfile: "infra/docker/Dockerfile",
     tags: [hostname("mcp")],
-    args: { NODE_ENV: isProduction ? "production" : "development" },
+    args: { NODE_ENV: isProduction ? "production" : "development", BUILD_SCRIPT: "build:ecs" },
   },
   environment: {
     HEBO_MODE: "mcp",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "bun run --workspaces --if-present --sequential build",
+    "build:ecs": "bun run --filter '!@hebo/console' --if-present --sequential build",
     "clean": "git clean -fdx -e '.env*'",
     "db:migrate": "bun run --workspaces --if-present --sequential db:migrate",
     "db:reset": "bun run --workspaces --if-present --sequential db:reset",


### PR DESCRIPTION
## Summary
- Skip the `@hebo/console` Vite build (~5m 21s) when building Docker images for ECS services, since the console is served via CloudFront/StaticSite
- Add a `BUILD_SCRIPT` build arg to the Dockerfile (defaults to `build`) and a `build:ecs` script in package.json that filters out `@hebo/console`
- ECS service stacks pass `BUILD_SCRIPT: "build:ecs"` to build only the 4 backend services (api, auth, gateway, mcp), while the standalone publish pipeline uses the default and builds all 5

## Why
The production deploy takes ~21 min. The biggest bottleneck is `bun run build` inside the Docker image, which builds all workspaces including the console frontend. The console Vite client build alone takes **5m 21s**. The ECS services never use the console assets — they're served from S3/CloudFront via `sst.aws.StaticSite`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration and deployment infrastructure to support configurable build strategies for containerized services, enabling more flexible and consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->