### PR TITLE
fix(console): return model ID from ModelSelector itemToStringValue

### DIFF
--- a/apps/console/app/components/ui/ModelSelector.tsx
+++ b/apps/console/app/components/ui/ModelSelector.tsx
@@ -68,7 +68,7 @@ function ModelSelector({
       disabled={disabled ?? !hasModels}
       items={groupedItems}
       itemToStringLabel={(modelId) => models?.[modelId]?.name ?? modelId}
-      itemToStringValue={(modelId) => models?.[modelId]?.name ?? modelId}
+      itemToStringValue={(modelId) => modelId}
       filter={(modelId, query) => {
         if (!query) return true;
         const m = models?.[modelId];


### PR DESCRIPTION
Fix the "Bring Your Own Provider" dropdown appearing empty by returning the model ID instead of the display name from `itemToStringValue`.

The regression was introduced in #436 when `ModelSelector` was refactored to use a Combobox.

Fixes #446

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selector value handling to ensure consistent and reliable form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->