### PR TITLE
fix(console): exclude toggle labels from trace message copy

### DIFF
--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
@@ -341,7 +341,7 @@ function MessageBlock({ message }: { message: TraceMessage }) {
             )}
           </div>
 
-          <CopyButton value={() => contentRef.current?.innerText ?? ""} />
+          <CopyButton sourceRef={contentRef} />
         </div>
 
         {!reasoning && texts.length === 0 && toolCalls.length === 0 && otherParts.length === 0 ? (
@@ -369,7 +369,7 @@ function MessageBlock({ message }: { message: TraceMessage }) {
 
             {toolCalls.map((tc, index) => (
               <div key={`tool-call:${index}`} className="space-y-2">
-                <Badge variant="outline">
+                <Badge variant="outline" data-copy-ignore>
                   <Wrench className="size-3" />
                   {tc.name}
                 </Badge>
@@ -379,7 +379,10 @@ function MessageBlock({ message }: { message: TraceMessage }) {
 
             {otherParts.map((part, index) => (
               <div key={`${part.type}:${index}`} className="space-y-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase">
+                <div
+                  data-copy-ignore
+                  className="text-xs font-medium text-muted-foreground uppercase"
+                >
                   {part.type}
                 </div>
                 <CollapsibleCode code={part.value} maxLength={300} />
@@ -409,6 +412,7 @@ function CollapsibleText({ text, maxLength }: { text: string; maxLength: number 
       </p>
       {needsTruncation && (
         <CollapsibleTrigger
+          data-copy-ignore
           render={
             <Button variant="ghost" size="sm" className={COLLAPSE_TOGGLE_CLASS_NAME}>
               {expanded ? <ChevronUp className="size-3" /> : <ChevronRight className="size-3" />}
@@ -437,6 +441,7 @@ function CollapsibleCode({ code, maxLength }: { code: string; maxLength: number 
       </pre>
       {needsTruncation && (
         <CollapsibleTrigger
+          data-copy-ignore
           render={
             <Button variant="ghost" size="sm" className={COLLAPSE_TOGGLE_CLASS_NAME}>
               {expanded ? <ChevronUp className="size-3" /> : <ChevronRight className="size-3" />}
@@ -453,6 +458,7 @@ function ExpandableContent({ label, children }: { label: string; children: React
   return (
     <Collapsible>
       <CollapsibleTrigger
+        data-copy-ignore
         render={
           <Button variant="ghost" size="sm" className={cn("group", INLINE_DISCLOSURE_CLASS_NAME)}>
             <ChevronRight className="size-3 transition-transform group-data-panel-open:rotate-90" />
@@ -460,7 +466,9 @@ function ExpandableContent({ label, children }: { label: string; children: React
           </Button>
         }
       />
-      <CollapsibleContent className="pt-1">{children}</CollapsibleContent>
+      <CollapsibleContent keepMounted className="pt-1">
+        {children}
+      </CollapsibleContent>
     </Collapsible>
   );
 }

--- a/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
+++ b/apps/console/app/routes/_shell.agent.$agentSlug.branch.$branchSlug.traces.($traceId)/details.tsx
@@ -341,7 +341,7 @@ function MessageBlock({ message }: { message: TraceMessage }) {
             )}
           </div>
 
-          <CopyButton sourceRef={contentRef} />
+          <CopyButton value={contentRef} />
         </div>
 
         {!reasoning && texts.length === 0 && toolCalls.length === 0 && otherParts.length === 0 ? (

--- a/packages/shared-ui/src/components/Code.tsx
+++ b/packages/shared-ui/src/components/Code.tsx
@@ -4,27 +4,13 @@ import { cn } from "../lib/utils";
 import { CopyButton } from "./CopyButton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 
-const getNodeText = (node: React.ReactNode): string => {
-  if (typeof node === "string" || typeof node === "number") {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    return React.Children.toArray(node)
-      .map((child) => getNodeText(child))
-      .join("");
-  }
-  if (React.isValidElement(node)) {
-    return getNodeText((node as React.ReactElement<{ children?: React.ReactNode }>).props.children);
-  }
-  return "";
-};
-
 type CodeBlockProps = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
   title?: React.ReactNode;
 };
 
 export function CodeBlock({ children, className, title, ...props }: CodeBlockProps) {
+  const preRef = React.useRef<HTMLPreElement>(null);
   return (
     <div
       data-slot="code-block"
@@ -37,15 +23,15 @@ export function CodeBlock({ children, className, title, ...props }: CodeBlockPro
       {title ? (
         <div className="flex items-center justify-between gap-1 bg-accent py-0.5 pr-1 pl-2">
           <span className="text-sm font-medium text-foreground">{title}</span>
-          <CopyButton value={getNodeText(children)} className="" />
+          <CopyButton value={preRef} className="" />
         </div>
       ) : (
-        <CopyButton
-          value={getNodeText(children)}
-          className="absolute top-0 right-0 z-10 bg-background p-2.5"
-        />
+        <CopyButton value={preRef} className="absolute top-0 right-0 z-10 bg-background p-2.5" />
       )}
-      <pre className="h-full w-full overflow-auto p-2 font-mono text-sm whitespace-pre">
+      <pre
+        ref={preRef}
+        className="h-full w-full overflow-auto p-2 font-mono text-sm whitespace-pre"
+      >
         <code>{children}</code>
       </pre>
     </div>

--- a/packages/shared-ui/src/components/CopyButton.tsx
+++ b/packages/shared-ui/src/components/CopyButton.tsx
@@ -10,48 +10,24 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
  */
 const COPY_IGNORE_ATTR = "data-copy-ignore";
 
-const BLOCK_TAG_PATTERN =
-  /^(ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|DD|DETAILS|DIALOG|DIV|DL|DT|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|LI|MAIN|NAV|OL|P|PRE|SECTION|SUMMARY|TABLE|TR|UL)$/;
+const BLOCK_TAGS = new Set(["DIV", "P", "PRE"]);
 
 function collectCopyText(root: HTMLElement): string {
-  const chunks: string[] = [];
+  if (root.tagName === "PRE") return root.textContent ?? "";
 
-  const pushBlockBreak = () => {
-    const last = chunks.at(-1);
-    if (last !== undefined && !last.endsWith("\n")) {
-      chunks.push("\n");
-    }
-  };
-
-  const walk = (node: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      chunks.push(node.nodeValue ?? "");
-      return;
-    }
-    if (node.nodeType !== Node.ELEMENT_NODE) return;
-
+  const walk = (node: Node): string => {
+    if (node.nodeType === Node.TEXT_NODE) return node.nodeValue ?? "";
+    if (node.nodeType !== Node.ELEMENT_NODE) return "";
     const el = node as HTMLElement;
-    if (el.hasAttribute(COPY_IGNORE_ATTR)) return;
-
-    if (el.tagName === "BR") {
-      chunks.push("\n");
-      return;
-    }
-
-    const isBlock = BLOCK_TAG_PATTERN.test(el.tagName);
-    if (isBlock) pushBlockBreak();
-
-    for (const child of Array.from(el.childNodes)) walk(child);
-
-    if (isBlock) pushBlockBreak();
+    if (el.hasAttribute(COPY_IGNORE_ATTR)) return "";
+    if (el.tagName === "BR") return "\n";
+    const inner = Array.from(el.childNodes)
+      .map((child) => walk(child))
+      .join("");
+    return BLOCK_TAGS.has(el.tagName) ? `\n${inner}\n` : inner;
   };
 
-  walk(root);
-
-  return chunks
-    .join("")
-    .replaceAll(/\n{3,}/g, "\n\n")
-    .trim();
+  return walk(root).replaceAll(/\n+/g, "\n").trim();
 }
 
 /**

--- a/packages/shared-ui/src/components/CopyButton.tsx
+++ b/packages/shared-ui/src/components/CopyButton.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 
 /**
  * Elements carrying this attribute (including their descendants) are excluded
- * when `sourceRef` is used to derive the clipboard text from the DOM.
+ * when a DOM `RefObject` is passed as `value` to derive the clipboard text.
  */
 const COPY_IGNORE_ATTR = "data-copy-ignore";
 
@@ -48,39 +48,35 @@ function collectCopyText(root: HTMLElement): string {
 
   walk(root);
 
-  return chunks.join("").replaceAll(/\n{3,}/g, "\n\n").trim();
+  return chunks
+    .join("")
+    .replaceAll(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
-type CopyButtonOwnProps = {
-  className?: string;
-  disabled?: boolean;
-  tooltip?: string;
-  icon?: React.ReactNode;
-  /**
-   * The text to copy. Can be a string or a function returning a string
-   * (evaluated on click, so large strings aren't held in memory between renders).
-   */
-  value?: string | (() => string);
-  /**
-   * Ref to a DOM subtree whose text content should be copied. The subtree is
-   * walked on click, skipping elements annotated with `data-copy-ignore`.
-   * Text inside hidden / collapsed descendants is still captured — visibility
-   * is not respected on purpose, so collapsed content is copied in full.
-   *
-   * When both `sourceRef` and `value` are provided, `sourceRef` takes precedence.
-   */
-  sourceRef?: React.RefObject<HTMLElement | null>;
-};
+/**
+ * Source of the text to copy. One of:
+ * - `string` — copied verbatim.
+ * - `() => string` — evaluated on click, so large strings aren't built on every render.
+ * - `RefObject<HTMLElement>` — the subtree is walked on click, skipping
+ *   `[data-copy-ignore]` descendants. Hidden / collapsed text is captured in full.
+ */
+type CopyValue = string | (() => string) | React.RefObject<HTMLElement | null>;
 
 export function CopyButton({
   value,
-  sourceRef,
   className,
   disabled = false,
   tooltip = "Copy to Clipboard",
   icon = <Copy />,
   ...props
-}: CopyButtonOwnProps & Omit<React.ComponentProps<"button">, "value">) {
+}: {
+  value: CopyValue;
+  className?: string;
+  disabled?: boolean;
+  tooltip?: string;
+  icon?: React.ReactNode;
+} & Omit<React.ComponentProps<"button">, "value">) {
   const [hasCopied, setHasCopied] = React.useState(false);
 
   React.useEffect(() => {
@@ -94,9 +90,9 @@ export function CopyButton({
   }, [hasCopied]);
 
   const resolveText = (): string => {
-    if (sourceRef?.current) return collectCopyText(sourceRef.current);
+    if (typeof value === "string") return value;
     if (typeof value === "function") return value();
-    return value ?? "";
+    return value.current ? collectCopyText(value.current) : "";
   };
 
   const copy = async () => {

--- a/packages/shared-ui/src/components/CopyButton.tsx
+++ b/packages/shared-ui/src/components/CopyButton.tsx
@@ -4,20 +4,83 @@ import * as React from "react";
 import { cn } from "../lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 
+/**
+ * Elements carrying this attribute (including their descendants) are excluded
+ * when `sourceRef` is used to derive the clipboard text from the DOM.
+ */
+const COPY_IGNORE_ATTR = "data-copy-ignore";
+
+const BLOCK_TAG_PATTERN =
+  /^(ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|DD|DETAILS|DIALOG|DIV|DL|DT|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|LI|MAIN|NAV|OL|P|PRE|SECTION|SUMMARY|TABLE|TR|UL)$/;
+
+function collectCopyText(root: HTMLElement): string {
+  const chunks: string[] = [];
+
+  const pushBlockBreak = () => {
+    const last = chunks.at(-1);
+    if (last !== undefined && !last.endsWith("\n")) {
+      chunks.push("\n");
+    }
+  };
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      chunks.push(node.nodeValue ?? "");
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const el = node as HTMLElement;
+    if (el.hasAttribute(COPY_IGNORE_ATTR)) return;
+
+    if (el.tagName === "BR") {
+      chunks.push("\n");
+      return;
+    }
+
+    const isBlock = BLOCK_TAG_PATTERN.test(el.tagName);
+    if (isBlock) pushBlockBreak();
+
+    for (const child of Array.from(el.childNodes)) walk(child);
+
+    if (isBlock) pushBlockBreak();
+  };
+
+  walk(root);
+
+  return chunks.join("").replaceAll(/\n{3,}/g, "\n\n").trim();
+}
+
+type CopyButtonOwnProps = {
+  className?: string;
+  disabled?: boolean;
+  tooltip?: string;
+  icon?: React.ReactNode;
+  /**
+   * The text to copy. Can be a string or a function returning a string
+   * (evaluated on click, so large strings aren't held in memory between renders).
+   */
+  value?: string | (() => string);
+  /**
+   * Ref to a DOM subtree whose text content should be copied. The subtree is
+   * walked on click, skipping elements annotated with `data-copy-ignore`.
+   * Text inside hidden / collapsed descendants is still captured — visibility
+   * is not respected on purpose, so collapsed content is copied in full.
+   *
+   * When both `sourceRef` and `value` are provided, `sourceRef` takes precedence.
+   */
+  sourceRef?: React.RefObject<HTMLElement | null>;
+};
+
 export function CopyButton({
   value,
+  sourceRef,
   className,
   disabled = false,
   tooltip = "Copy to Clipboard",
   icon = <Copy />,
   ...props
-}: {
-  value: string | (() => string);
-  className?: string;
-  disabled?: boolean;
-  tooltip?: string;
-  icon?: React.ReactNode;
-} & Omit<React.ComponentProps<"button">, "value">) {
+}: CopyButtonOwnProps & Omit<React.ComponentProps<"button">, "value">) {
   const [hasCopied, setHasCopied] = React.useState(false);
 
   React.useEffect(() => {
@@ -30,9 +93,15 @@ export function CopyButton({
     };
   }, [hasCopied]);
 
+  const resolveText = (): string => {
+    if (sourceRef?.current) return collectCopyText(sourceRef.current);
+    if (typeof value === "function") return value();
+    return value ?? "";
+  };
+
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(typeof value === "function" ? value() : value);
+      await navigator.clipboard.writeText(resolveText());
       setHasCopied(true);
     } catch (error) {
       console.error("Failed to copy to clipboard:", error);


### PR DESCRIPTION
## Summary
- Teach `CopyButton` to accept a DOM subtree via its `value` prop (now `string | () => string | RefObject<HTMLElement>`) and walk the tree itself, skipping any subtree marked with `data-copy-ignore`.
- Annotate the trace message toggles, the Reasoning disclosure trigger, and the tool-call / other-part label elements with `data-copy-ignore`.
- Drop `getNodeText` from `Code.tsx` and point `CopyButton` at the `<pre>` ref so there's one copy of the text in the DOM and the clipboard string is only built on click.
- Walker uses `textContent` semantics so collapsed / hidden text is still copied in full (no `line-clamp` truncation, Reasoning panel uses `keepMounted`).

Fixes #460

## Test plan
- [ ] Long message still collapsed: copy → full text, no "More" / "Less".
- [ ] Long message expanded: copy → full text, no "More" / "Less".
- [ ] Message with reasoning (collapsed): copy → reasoning text is present, "Reasoning" trigger label is not.
- [ ] Message with tool calls: copy → arguments present, tool-call badge name absent.
- [ ] CodeBlock copy → pasted code matches rendered content (title and untitled variants).
- [ ] Other `CopyButton` sites (Raw JSON, metadata rows, alias paths, Input) still copy expected string.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Copy-to-clipboard now ignores UI controls (badges, expand/collapse triggers) so copied content is cleaner
  * Copy behavior expanded to derive text from rendered elements for more accurate results when copying code or message blocks
  * Expandable content now keeps children mounted after collapse to preserve state and improve responsiveness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/8monkey-ai/hebo-platform/pull/464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->