### PR TITLE
chore: upgrade oxlint to 1.68 and oxlint-tsgolint to 0.22.1

### DIFF
--- a/apps/api/src/modules/providers/types.ts
+++ b/apps/api/src/modules/providers/types.ts
@@ -156,7 +156,7 @@ export const ModelConfigSchema = z.object({
   alias: z
     .string()
     .min(1)
-    .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/),
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/u),
   type: z.string().min(1),
   routing: z
     .object({

--- a/apps/api/src/modules/traces/utils.ts
+++ b/apps/api/src/modules/traces/utils.ts
@@ -14,7 +14,7 @@ export function parseString(value: unknown): string {
 }
 
 function normalizeJsonUnicodeEscapes(value: string): string {
-  return value.replaceAll(/\\u\{([0-9a-fA-F]+)\}/g, (match, hex: string) => {
+  return value.replaceAll(/\\u\{([0-9a-fA-F]+)\}/gu, (match, hex: string) => {
     const codePoint = Number.parseInt(hex, 16);
     return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
   });

--- a/apps/console/app/lib/utils.ts
+++ b/apps/console/app/lib/utils.ts
@@ -11,13 +11,13 @@ export function getCookie(name: string): string | undefined {
  * @returns The formatted shortcut string (e.g., '⌘P' on Mac, 'Ctrl P' on other platforms)
  */
 export const kbs = (shortcut: string): string => {
-  const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+  const isMac = /Mac|iPhone|iPad|iPod/u.test(navigator.userAgent);
 
   const map: Record<string, string> = isMac
     ? { mod: "⌘", option: "⌥", ctrl: "⌃", shift: "⇧" }
     : { mod: "Ctrl", option: "Alt", ctrl: "Ctrl", shift: "Shift" };
 
-  return shortcut.replaceAll("+", "").replaceAll(/(mod|option|ctrl|shift)/gi, (match) => {
+  return shortcut.replaceAll("+", "").replaceAll(/(mod|option|ctrl|shift)/giu, (match) => {
     const lower = match.toLowerCase();
     return map[lower] ?? match.toUpperCase();
   });
@@ -33,7 +33,7 @@ export const formatDateTime = (date: Date) => {
 // Create human readable labels, e.g. "serviceAccount" => "Service Account", "iam-role" => "Iam Role"
 export function labelize(value: string) {
   return value
-    .replaceAll(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replaceAll(/([a-z\d])([A-Z])/gu, "$1 $2")
     .replaceAll("-", " ")
-    .replaceAll(/\b\w/g, (c) => c.toUpperCase());
+    .replaceAll(/\b\w/gu, (c) => c.toUpperCase());
 }

--- a/apps/console/app/lib/zod.ts
+++ b/apps/console/app/lib/zod.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { labelize } from "./utils";
 
-export const identifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.toString();
+export const identifierPattern = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/u.toString();
 
 function required(path: PropertyKey[] | undefined): { message: string } {
   const key = path?.at(-1);

--- a/apps/console/app/mocks/db.ts
+++ b/apps/console/app/mocks/db.ts
@@ -65,7 +65,9 @@ export const createDb = () => {
 type DB = ReturnType<typeof createDb>;
 
 declare global {
+  // oxlint-disable-next-line no-underscore-dangle -- HMR global singleton pattern
   var __heboDb: DB | undefined;
 }
 
+// oxlint-disable-next-line no-underscore-dangle -- HMR global singleton pattern
 export const db: DB = (globalThis.__heboDb ??= createDb());

--- a/apps/console/app/mocks/db.ts
+++ b/apps/console/app/mocks/db.ts
@@ -65,9 +65,7 @@ export const createDb = () => {
 type DB = ReturnType<typeof createDb>;
 
 declare global {
-  // oxlint-disable-next-line no-underscore-dangle -- HMR global singleton pattern
-  var __heboDb: DB | undefined;
+  var heboDb: DB | undefined;
 }
 
-// oxlint-disable-next-line no-underscore-dangle -- HMR global singleton pattern
-export const db: DB = (globalThis.__heboDb ??= createDb());
+export const db: DB = (globalThis.heboDb ??= createDb());

--- a/apps/console/app/mocks/middleware/chaos.ts
+++ b/apps/console/app/mocks/middleware/chaos.ts
@@ -25,7 +25,7 @@ export function addChaos(handlers: HttpHandler[]): HttpHandler[] {
       typeof h.info?.method === "string"
         ? (h.info.method.toLowerCase() as keyof typeof http)
         : "all";
-    const path = h.info?.path ?? /.*/;
+    const path = h.info?.path ?? /.*/u;
 
     return [http[method](path, chaosResolver), h];
   });

--- a/apps/console/app/mocks/middleware/delays.ts
+++ b/apps/console/app/mocks/middleware/delays.ts
@@ -15,7 +15,7 @@ export function addDelays(handlers: HttpHandler[]): HttpHandler[] {
         : "all";
     const duration = method ? METHOD_DELAYS[method] : undefined;
     if (!method || !duration) return [h];
-    const path = h.info?.path ?? /.*/;
+    const path = h.info?.path ?? /.*/u;
 
     return [http[method](path, () => delay(duration)), h];
   });

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig(({ command }) => {
       tailwindcss(),
       reactRouter(),
       babel({
-        filter: (id) => /\.[jt]sx?$/.test(id) && !id.includes("node_modules"),
+        filter: (id) => /\.[jt]sx?$/u.test(id) && !id.includes("node_modules"),
         babelConfig: {
           presets: ["@babel/preset-typescript"],
           plugins: [["babel-plugin-react-compiler"]],

--- a/apps/gateway/src/gateway.ts
+++ b/apps/gateway/src/gateway.ts
@@ -24,9 +24,9 @@ import {
 import { createProvider, loadProviderSecrets } from "./lib/provider";
 
 // Disable Bun's hardcoded 5-minute fetch timeout (https://github.com/oven-sh/bun/issues/16682)
-const _fetch = globalThis.fetch;
-// @ts-expect-error -- Bun-specific `timeout` option not in standard RequestInit
-globalThis.fetch = ((input, init) => _fetch(input, { ...init, timeout: false })) as typeof fetch;
+const originalFetch = globalThis.fetch;
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+  originalFetch(input, { ...init, timeout: false } as RequestInit)) as typeof fetch;
 
 export const BASE_PATH = "/v1";
 
@@ -79,8 +79,14 @@ export const gw = gateway({
     minimax: createProvider("minimax", { authMode: "api-key", apiKey: SECRETS.MINIMAX_API_KEY }),
     zhipu: createProvider("zhipu", { authMode: "api-key", apiKey: SECRETS.ZHIPU_API_KEY }),
     moonshot: createProvider("moonshot", { authMode: "api-key", apiKey: SECRETS.MOONSHOT_API_KEY }),
-    fireworks: createProvider("fireworks", { authMode: "api-key", apiKey: SECRETS.FIREWORKS_API_KEY }),
-    deepinfra: createProvider("deepinfra", { authMode: "api-key", apiKey: SECRETS.DEEPINFRA_API_KEY }),
+    fireworks: createProvider("fireworks", {
+      authMode: "api-key",
+      apiKey: SECRETS.FIREWORKS_API_KEY,
+    }),
+    deepinfra: createProvider("deepinfra", {
+      authMode: "api-key",
+      apiKey: SECRETS.DEEPINFRA_API_KEY,
+    }),
     togetherai: createProvider("togetherai", {
       authMode: "api-key",
       apiKey: SECRETS.TOGETHERAI_API_KEY,

--- a/bun.lock
+++ b/bun.lock
@@ -9,8 +9,8 @@
         "check-dependency-version-consistency": "^6.0.0",
         "lefthook": "^2.0.15",
         "oxfmt": "^0.45.0",
-        "oxlint": "^1.60.0",
-        "oxlint-tsgolint": "^0.21.1",
+        "oxlint": "^1.68.0",
+        "oxlint-tsgolint": "^0.22.1",
         "sst": "catalog:",
         "tailwindcss": "catalog:",
         "typescript": "catalog:",
@@ -815,55 +815,55 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.45.0", "", { "os": "win32", "cpu": "x64" }, "sha512-w5MMTRCK1dpQeRA+HHqXQXyN33DlG/N2LOYxJmaT4fJjcmZrbNnqw7SmIk7I2/a2493PPLZ+2E/Ar6t2iKVMug=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.21.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7TLjyWe4wG9saJc992VWmaHq2hwKfOEEVTjheReXJXaDhavMZI4X9a6nKhbEng4IVkYtzjD2jw16vw2WFXLYLw=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.22.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.21.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7wf9Wf75nTzA7zpL9myhFe2RKvfuqGUOADNvUooCjEWvh7hmPz3lSEqTMh5Z/VQhzsG04mM9ACyghxhRzq7zFw=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.22.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.21.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-IPuQN/Vd0Rjklg/cCGBbQyUuRBp2f6LQXpZYwk5ivOR6V/+CgiYsv8pn/PVY7gjeyoNvPQrXB7xMjHUO2YZbdw=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.22.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.21.1", "", { "os": "linux", "cpu": "x64" }, "sha512-d1niGuTbh2qiv7dR7tqkbOcM5cIR63of0lMBFdEQavL1KrJV8zuRdwdi68K7MNGdgoR+J5A9ajpGGvsHwp1bPg=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.22.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.21.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ICu9y2JLnFPvFqstnWPPNqBM8LK8BWw2OTeaR0UgEMm4hOSbrZAKv1/hwZYyiLqnCNjBL87AGSQIgTHCYlsipw=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.22.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.21.1", "", { "os": "win32", "cpu": "x64" }, "sha512-cTEFCFjCj6iXfrSHcvajSPNqhEA4TxSzU3gFxbdGSAUTNXGToU99IbdhWAPSbhcucoym0XE4Zl7E41NiSkNTug=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.22.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.68.0", "", { "os": "android", "cpu": "arm" }, "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.68.0", "", { "os": "android", "cpu": "arm64" }, "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.68.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.68.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.68.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.68.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.68.0", "", { "os": "linux", "cpu": "arm" }, "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.68.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.68.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.68.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.68.0", "", { "os": "linux", "cpu": "none" }, "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.68.0", "", { "os": "linux", "cpu": "none" }, "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.68.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.68.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.68.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.68.0", "", { "os": "none", "cpu": "arm64" }, "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.68.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.68.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.68.0", "", { "os": "win32", "cpu": "x64" }, "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -2335,9 +2335,9 @@
 
     "oxfmt": ["oxfmt@0.45.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.45.0", "@oxfmt/binding-android-arm64": "0.45.0", "@oxfmt/binding-darwin-arm64": "0.45.0", "@oxfmt/binding-darwin-x64": "0.45.0", "@oxfmt/binding-freebsd-x64": "0.45.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.45.0", "@oxfmt/binding-linux-arm-musleabihf": "0.45.0", "@oxfmt/binding-linux-arm64-gnu": "0.45.0", "@oxfmt/binding-linux-arm64-musl": "0.45.0", "@oxfmt/binding-linux-ppc64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-musl": "0.45.0", "@oxfmt/binding-linux-s390x-gnu": "0.45.0", "@oxfmt/binding-linux-x64-gnu": "0.45.0", "@oxfmt/binding-linux-x64-musl": "0.45.0", "@oxfmt/binding-openharmony-arm64": "0.45.0", "@oxfmt/binding-win32-arm64-msvc": "0.45.0", "@oxfmt/binding-win32-ia32-msvc": "0.45.0", "@oxfmt/binding-win32-x64-msvc": "0.45.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg=="],
 
-    "oxlint": ["oxlint@1.60.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.60.0", "@oxlint/binding-android-arm64": "1.60.0", "@oxlint/binding-darwin-arm64": "1.60.0", "@oxlint/binding-darwin-x64": "1.60.0", "@oxlint/binding-freebsd-x64": "1.60.0", "@oxlint/binding-linux-arm-gnueabihf": "1.60.0", "@oxlint/binding-linux-arm-musleabihf": "1.60.0", "@oxlint/binding-linux-arm64-gnu": "1.60.0", "@oxlint/binding-linux-arm64-musl": "1.60.0", "@oxlint/binding-linux-ppc64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-musl": "1.60.0", "@oxlint/binding-linux-s390x-gnu": "1.60.0", "@oxlint/binding-linux-x64-gnu": "1.60.0", "@oxlint/binding-linux-x64-musl": "1.60.0", "@oxlint/binding-openharmony-arm64": "1.60.0", "@oxlint/binding-win32-arm64-msvc": "1.60.0", "@oxlint/binding-win32-ia32-msvc": "1.60.0", "@oxlint/binding-win32-x64-msvc": "1.60.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw=="],
+    "oxlint": ["oxlint@1.68.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.68.0", "@oxlint/binding-android-arm64": "1.68.0", "@oxlint/binding-darwin-arm64": "1.68.0", "@oxlint/binding-darwin-x64": "1.68.0", "@oxlint/binding-freebsd-x64": "1.68.0", "@oxlint/binding-linux-arm-gnueabihf": "1.68.0", "@oxlint/binding-linux-arm-musleabihf": "1.68.0", "@oxlint/binding-linux-arm64-gnu": "1.68.0", "@oxlint/binding-linux-arm64-musl": "1.68.0", "@oxlint/binding-linux-ppc64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-musl": "1.68.0", "@oxlint/binding-linux-s390x-gnu": "1.68.0", "@oxlint/binding-linux-x64-gnu": "1.68.0", "@oxlint/binding-linux-x64-musl": "1.68.0", "@oxlint/binding-openharmony-arm64": "1.68.0", "@oxlint/binding-win32-arm64-msvc": "1.68.0", "@oxlint/binding-win32-ia32-msvc": "1.68.0", "@oxlint/binding-win32-x64-msvc": "1.68.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.21.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.21.1", "@oxlint-tsgolint/darwin-x64": "0.21.1", "@oxlint-tsgolint/linux-arm64": "0.21.1", "@oxlint-tsgolint/linux-x64": "0.21.1", "@oxlint-tsgolint/win32-arm64": "0.21.1", "@oxlint-tsgolint/win32-x64": "0.21.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-O2hxiT14C2HJkwzBU6CQBFPoagSd/IcV+Tt3e3UUaXFwbW4BO5DSDPSSboc3UM5MIDY+MLyepvtQwBQafNxWdw=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
 
     "p-defer": ["p-defer@1.0.0", "", {}, "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "check-dependency-version-consistency": "^6.0.0",
     "lefthook": "^2.0.15",
     "oxfmt": "^0.45.0",
-    "oxlint": "^1.60.0",
-    "oxlint-tsgolint": "^0.21.1",
+    "oxlint": "^1.68.0",
+    "oxlint-tsgolint": "^0.22.1",
     "sst": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"

--- a/packages/aikit-ui/src/blocks/Chat.tsx
+++ b/packages/aikit-ui/src/blocks/Chat.tsx
@@ -229,6 +229,7 @@ export function Chat({
                           from={message.role}
                           key={`${message.id}-${i}`}
                           tabIndex={-1}
+                          // oxlint-disable-next-line prefer-tag-over-role -- role is forwarded to the internal DOM element
                           role="article"
                           aria-label={`Message from ${message.role}`}
                         >
@@ -302,6 +303,7 @@ export function Chat({
                 {/* oxlint-enable no-array-index-key */}
               </div>
             ))}
+            {/* oxlint-disable-next-line prefer-tag-over-role -- role is forwarded to the internal DOM element */}
             {status === "submitted" && <Spinner role="status" />}
             {error && (
               <Alert variant="destructive" className="overflow-x-auto">
@@ -320,6 +322,7 @@ export function Chat({
       {/* Input area */}
       <PromptInput
         onSubmit={handleSubmit}
+        // oxlint-disable-next-line prefer-tag-over-role -- role is forwarded to the internal DOM element
         role="form"
         className="mt-4 rounded-md bg-background"
         globalDrop

--- a/packages/shared-api/utils/slug.ts
+++ b/packages/shared-api/utils/slug.ts
@@ -18,7 +18,7 @@ export const slugFromName = (name: string | null | undefined, email: string): st
   if (!name) return slugFromString(email.split("@")[0].slice(0, 6), 6);
 
   const normalized = slugify(name, { separator: " " });
-  const parts = normalized.trim().split(/\s+/);
+  const parts = normalized.trim().split(/\s+/u);
   const base =
     parts.length > 1 ? parts[0].slice(0, 3) + parts.at(-1)!.slice(0, 3) : normalized.slice(0, 6);
 

--- a/packages/shared-api/utils/url.ts
+++ b/packages/shared-api/utils/url.ts
@@ -25,7 +25,7 @@ export function getRootDomain(baseUrl: string | undefined) {
   const sld = parts.at(-2);
 
   // ccTLDs with a registry second level (e.g. co.uk, com.au, org.nz)
-  const take3 = tld?.length === 2 && /^(co|com|net|org|edu|gov|ac|me|ne)$/.test(sld ?? "");
+  const take3 = tld?.length === 2 && /^(co|com|net|org|edu|gov|ac|me|ne)$/u.test(sld ?? "");
 
   return parts.slice(take3 ? -3 : -2).join(".");
 }

--- a/packages/shared-ui/src/components/CopyButton.tsx
+++ b/packages/shared-ui/src/components/CopyButton.tsx
@@ -4,12 +4,14 @@ import * as React from "react";
 import { cn } from "../lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 
+const DEFAULT_ICON = <Copy />;
+
 export function CopyButton({
   value,
   className,
   disabled = false,
   tooltip = "Copy to Clipboard",
-  icon = <Copy />,
+  icon = DEFAULT_ICON,
   ...props
 }: {
   value: string | (() => string);

--- a/packages/shared-ui/src/components/Sidebar.tsx
+++ b/packages/shared-ui/src/components/Sidebar.tsx
@@ -4,6 +4,8 @@ import { Button } from "../_shadcn/ui/button";
 import { useSidebar, Sidebar as ShadCnSidebar } from "../_shadcn/ui/sidebar";
 import { cn } from "../lib/utils";
 
+const DEFAULT_SIDEBAR_TRIGGER_ICON = <PanelLeftIcon />;
+
 export function Sidebar({
   side = "left",
   variant = "sidebar",
@@ -35,7 +37,7 @@ export function Sidebar({
 export function SidebarTrigger({
   className,
   onClick,
-  icon = <PanelLeftIcon />,
+  icon = DEFAULT_SIDEBAR_TRIGGER_ICON,
   ...props
 }: React.ComponentProps<typeof Button> & {
   icon?: React.ReactNode;


### PR DESCRIPTION
## Summary

- Upgrades `oxlint` from `^1.60.0` to `^1.68.0` and `oxlint-tsgolint` from `^0.21.1` to `^0.22.1`
- Fixes tsgolint SIGPIPE crashes caused by peer dependency mismatch (oxlint 1.68 requires tsgolint >=0.22.1)
- Resolves newly enforced lint rules from the `pedantic` category added in oxlint 1.61–1.68

## Changes

| Rule | Fix |
|------|-----|
| `require-unicode-regexp` | Added `u` flag to all regex literals |
| `no-underscore-dangle` | Suppressed for HMR global (`__heboDb`), renamed `_fetch` → `originalFetch` |
| `no-object-type-as-default-prop` | Extracted JSX default values to module-level constants |
| `prefer-tag-over-role` | Suppressed for custom components that forward `role` to internal DOM elements |

## Test plan

- [x] `bun run typecheck` passes (exit code 0)
- [x] `bun run lint` passes (exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped developer tooling versions (`oxlint`, `oxlint-tsgolint`)
  * Minor runtime/init tweaks (global HMR variable rename, fetch wrapper override)

* **Refactor**
  * Improved pattern-matching by enabling Unicode-aware regexes across multiple modules
  * Extracted default component constants for icons

* **Style**
  * Added ESLint suppression comments for accessibility-related roles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->