### PR TITLE
feat(docker): inject console URLs as build args for self-hosted deploys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,8 @@ The Docker image is built from `infra/docker/Dockerfile` and published to Docker
 - **Release** — pushing a `v*` tag builds with `NODE_ENV=production` and tags the image as `v<semver>`
 - **Manual** — trigger the workflow manually for development builds
 
+The console's `VITE_API_URL`, `VITE_AUTH_URL`, `VITE_GATEWAY_URL` and `VITE_MAGICLINK_AUTH` are Vite constants baked into the static bundle, so the Dockerfile takes them as build args. The published image is built without them and falls back to `localhost`; self-hosters on a custom domain build their own image via `infra/self-hosted/docker-compose.build.yaml`.
+
 ### Cloud (AWS ECS)
 
 The repository uses GitHub Actions for CI/CD with SST managing the infrastructure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ The Docker image is built from `infra/docker/Dockerfile` and published to Docker
 - **Release** — pushing a `v*` tag builds with `NODE_ENV=production` and tags the image as `v<semver>`
 - **Manual** — trigger the workflow manually for development builds
 
-The console's `VITE_API_URL`, `VITE_AUTH_URL`, `VITE_GATEWAY_URL` and `VITE_MAGICLINK_AUTH` are Vite constants baked into the static bundle, so the Dockerfile takes them as build args. The published image is built without them and falls back to `localhost`; self-hosters on a custom domain build their own image via `infra/self-hosted/docker-compose.build.yaml`.
+The console's `VITE_*` values are Vite constants baked into the bundle, so the Dockerfile takes them as build args. The published image is built without them and falls back to `localhost`; custom-domain deployments build their own image via `infra/self-hosted/docker-compose.build.yaml`.
 
 ### Cloud (AWS ECS)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ VITE_API_URL=https://api.example.com
 VITE_AUTH_URL=https://auth.example.com
 VITE_GATEWAY_URL=https://gateway.example.com
 
-BASE_URL=https://api.example.com
+BASE_URL=https://auth.example.com
 NODE_ENV=production
 ```
 
@@ -94,6 +94,8 @@ docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
 ```
 
 `BASE_URL` configures the server side — CORS, the auth base URL, trusted origins and the session cookie domain. The console and the services must share a registrable domain (`example.com` above), the console must be on a subdomain rather than the apex, and every origin must be `https://`. Using OAuth additionally requires registering `${BASE_URL}/v1/callback/<provider>` with each provider.
+
+Point `BASE_URL` at your **auth** host. All five services share one `BASE_URL` in standalone mode, but only the auth service uses it literally — for the OAuth callback URL above — while CORS and cookies only need the registrable domain, which any subdomain resolves to. The one casualty is the `servers` URL advertised in the API and Gateway OpenAPI documents; it is cosmetic and affects generated client defaults rather than live traffic.
 
 ## How Hebo compares
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ cd infra/self-hosted
 docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
 ```
 
-`BASE_URL` configures the server side — CORS, the auth base URL, trusted origins and the session cookie domain. The console and the services must share a registrable domain (`example.com` above), the console must be on a subdomain rather than the apex, and every origin must be `https://`. Using OAuth additionally requires registering `${BASE_URL}/v1/callback/<provider>` with each provider.
+`BASE_URL` configures the server side: CORS, the auth base URL, trusted origins and the session cookie domain. Point it at your **auth** host — all services share one `BASE_URL` in standalone mode, and auth is the only one that uses it literally, deriving OAuth callbacks as `${BASE_URL}/v1/callback/<provider>` (register that with each provider). The console and the services must share a registrable domain (`example.com` above), the console must be on a subdomain rather than the apex, and every origin must be `https://`.
 
-Point `BASE_URL` at your **auth** host. All five services share one `BASE_URL` in standalone mode, but only the auth service uses it literally — for the OAuth callback URL above — while CORS and cookies only need the registrable domain, which any subdomain resolves to. The one casualty is the `servers` URL advertised in the API and Gateway OpenAPI documents; it is cosmetic and affects generated client defaults rather than live traffic.
+One side effect: the API and Gateway build the `servers` URL in their OpenAPI documents from `BASE_URL`, so it will name the auth host. That affects generated client defaults, not live traffic.
 
 ## How Hebo compares
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ Optional: OAuth (`GITHUB_CLIENT_ID`, `GOOGLE_CLIENT_ID`, …) and SMTP (`SMTP_HO
 
 See [`infra/self-hosted/.env.example`](infra/self-hosted/.env.example) for the full variable reference.
 
+#### Custom domains
+
+The console is a static SPA, so the API, Auth and Gateway URLs are compiled into its bundle at build time. The published image is built without them and falls back to `localhost`, which means **serving the console from your own domain requires building your own image** from a checkout of this repository.
+
+Set the URLs in `infra/self-hosted/.env`:
+
+```bash
+VITE_API_URL=https://api.example.com
+VITE_AUTH_URL=https://auth.example.com
+VITE_GATEWAY_URL=https://gateway.example.com
+
+BASE_URL=https://api.example.com
+NODE_ENV=production
+```
+
+Then build and start:
+
+```bash
+cd infra/self-hosted
+docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
+```
+
+`BASE_URL` configures the server side — CORS, the auth base URL, trusted origins and the session cookie domain. The console and the services must share a registrable domain (`example.com` above), the console must be on a subdomain rather than the apex, and every origin must be `https://`. Using OAuth additionally requires registering `${BASE_URL}/v1/callback/<provider>` with each provider.
+
 ## How Hebo compares
 
 |                 | Hebo              | Langfuse          | Helicone          | Portkey       | LiteLLM     | OpenRouter | Vercel AI  |

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -27,13 +27,10 @@ COPY --parents package.json bun.lock \
      ./
 RUN bun install --frozen-lockfile
 
-# Console service URLs are compiled into the static bundle by Vite, so they
-# have to be known here rather than at container start. Unset args stay empty
-# and the console falls back to its localhost defaults — fine for a local
-# `docker compose up`, but a custom-domain deployment must pass its own values
-# and therefore build its own image.
-#
-# Declared after `bun install` so changing a domain reuses the dependency layer.
+# Console URLs are Vite constants baked into the bundle, so they must be known
+# here rather than at container start. Unset args keep the localhost fallback in
+# apps/console/app/lib/env.ts. Placed after `bun install` so that changing a
+# domain reuses the dependency layer.
 ARG VITE_API_URL
 ARG VITE_AUTH_URL
 ARG VITE_GATEWAY_URL

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -27,6 +27,22 @@ COPY --parents package.json bun.lock \
      ./
 RUN bun install --frozen-lockfile
 
+# Console service URLs are compiled into the static bundle by Vite, so they
+# have to be known here rather than at container start. Unset args stay empty
+# and the console falls back to its localhost defaults — fine for a local
+# `docker compose up`, but a custom-domain deployment must pass its own values
+# and therefore build its own image.
+#
+# Declared after `bun install` so changing a domain reuses the dependency layer.
+ARG VITE_API_URL
+ARG VITE_AUTH_URL
+ARG VITE_GATEWAY_URL
+ARG VITE_MAGICLINK_AUTH
+ENV VITE_API_URL=$VITE_API_URL \
+    VITE_AUTH_URL=$VITE_AUTH_URL \
+    VITE_GATEWAY_URL=$VITE_GATEWAY_URL \
+    VITE_MAGICLINK_AUTH=$VITE_MAGICLINK_AUTH
+
 COPY . .
 RUN bun run build
 

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -14,6 +14,39 @@
 # IMPORTANT: Change this in production.
 # AUTH_SECRET=change-me-in-production
 
+# ── Custom domain (only needed if you are not using localhost) ──
+#
+# The console is a static SPA: its service URLs are compiled into the bundle
+# at build time, so these are BUILD arguments, not runtime settings. Setting
+# them here has no effect on the published image — you must build your own:
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
+#
+# VITE_API_URL=https://api.example.com
+# VITE_AUTH_URL=https://auth.example.com
+# VITE_GATEWAY_URL=https://gateway.example.com
+# VITE_MAGICLINK_AUTH=true      Set when SMTP is configured (see below) —
+#                               the console hides email+password login, which
+#                               the auth server disables whenever SMTP is set.
+#
+# Tag for the image you build. Override to push to your own registry.
+# HEBO_IMAGE=8monkey/hebo-platform:latest
+#
+# The server side needs matching configuration or sign-in will fail — the
+# console and the services must share a registrable domain (example.com):
+#
+# BASE_URL=https://api.example.com   Drives CORS, the better-auth base URL,
+#                                    trusted origins and the cookie domain.
+#                                    Unset = every origin is accepted.
+#                                    Once set, only https:// origins pass, and
+#                                    the console must be on a subdomain rather
+#                                    than the apex domain.
+# AUTH_URL=http://localhost:8523     Where API and Gateway reach the auth
+#                                    service. Leave as-is in standalone mode.
+# NODE_ENV=production                Required for Secure session cookies.
+#
+# With OAuth, register ${BASE_URL}/v1/callback/<provider> with each provider.
+
 # ── Database ──
 # Override to use an external Postgres instance.
 # POSTGRES_URL=postgresql://user:password@host:5432/hebo

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -35,12 +35,22 @@
 # The server side needs matching configuration or sign-in will fail — the
 # console and the services must share a registrable domain (example.com):
 #
-# BASE_URL=https://api.example.com   Drives CORS, the better-auth base URL,
+# BASE_URL=https://auth.example.com  Drives CORS, the better-auth base URL,
 #                                    trusted origins and the cookie domain.
 #                                    Unset = every origin is accepted.
 #                                    Once set, only https:// origins pass, and
 #                                    the console must be on a subdomain rather
 #                                    than the apex domain.
+#
+#                                    Use your AUTH host. Standalone shares one
+#                                    BASE_URL across all services, and auth is
+#                                    the only one that uses it literally (for
+#                                    the OAuth callback below) — CORS and
+#                                    cookies just need the registrable domain.
+#                                    Side effect: the API and Gateway OpenAPI
+#                                    documents advertise a `servers` URL built
+#                                    from it, so that URL will be wrong. It is
+#                                    cosmetic and does not affect live traffic.
 # AUTH_URL=http://localhost:8523     Where API and Gateway reach the auth
 #                                    service. Leave as-is in standalone mode.
 # NODE_ENV=production                Required for Secure session cookies.

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -14,45 +14,26 @@
 # IMPORTANT: Change this in production.
 # AUTH_SECRET=change-me-in-production
 
-# ── Custom domain (only needed if you are not using localhost) ──
+# ── Custom domain (not needed on localhost) ──
 #
-# The console is a static SPA: its service URLs are compiled into the bundle
-# at build time, so these are BUILD arguments, not runtime settings. Setting
-# them here has no effect on the published image — you must build your own:
-#
-#   docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
+# The console bakes these into its bundle at build time, so they are BUILD
+# arguments — set them here, then build your own image with
+# docker-compose.build.yaml. They have no effect on the published image.
 #
 # VITE_API_URL=https://api.example.com
 # VITE_AUTH_URL=https://auth.example.com
 # VITE_GATEWAY_URL=https://gateway.example.com
-# VITE_MAGICLINK_AUTH=true      Set when SMTP is configured (see below) —
-#                               the console hides email+password login, which
-#                               the auth server disables whenever SMTP is set.
+# VITE_MAGICLINK_AUTH=true                 Set when SMTP is configured below.
+# HEBO_IMAGE=8monkey/hebo-platform:latest  Tag for the image you build.
 #
-# Tag for the image you build. Override to push to your own registry.
-# HEBO_IMAGE=8monkey/hebo-platform:latest
+# The server side has to match or sign-in fails: console and services on one
+# registrable domain (example.com), console on a subdomain not the apex, and
+# https:// throughout.
 #
-# The server side needs matching configuration or sign-in will fail — the
-# console and the services must share a registrable domain (example.com):
-#
-# BASE_URL=https://auth.example.com  Drives CORS, the better-auth base URL,
-#                                    trusted origins and the cookie domain.
+# BASE_URL=https://auth.example.com  CORS, better-auth base URL, trusted
+#                                    origins, cookie domain. Use the AUTH host
+#                                    — OAuth callbacks derive from it literally.
 #                                    Unset = every origin is accepted.
-#                                    Once set, only https:// origins pass, and
-#                                    the console must be on a subdomain rather
-#                                    than the apex domain.
-#
-#                                    Use your AUTH host. Standalone shares one
-#                                    BASE_URL across all services, and auth is
-#                                    the only one that uses it literally (for
-#                                    the OAuth callback below) — CORS and
-#                                    cookies just need the registrable domain.
-#                                    Side effect: the API and Gateway OpenAPI
-#                                    documents advertise a `servers` URL built
-#                                    from it, so that URL will be wrong. It is
-#                                    cosmetic and does not affect live traffic.
-# AUTH_URL=http://localhost:8523     Where API and Gateway reach the auth
-#                                    service. Leave as-is in standalone mode.
 # NODE_ENV=production                Required for Secure session cookies.
 #
 # With OAuth, register ${BASE_URL}/v1/callback/<provider> with each provider.

--- a/infra/self-hosted/docker-compose.build.yaml
+++ b/infra/self-hosted/docker-compose.build.yaml
@@ -1,19 +1,13 @@
 # Hebo self-hosted — build the image locally instead of pulling it.
 #
-# Needed when the console is served from a custom domain. The console is a
-# static SPA whose API/Auth/Gateway URLs are compiled into the bundle by Vite
-# at build time, so the published image cannot know them — it always falls back
-# to localhost. Set the VITE_* variables in .env and build your own image.
+# Needed for custom domains: the console's service URLs are baked into its
+# bundle at build time, so the published image always points at localhost.
+# Set the VITE_* variables in .env, then:
 #
-# Requires a full checkout of the repository: the build context is the repo
-# root, not this directory.
-#
-# Usage:
 #   docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
 #
-# The result is tagged with HEBO_IMAGE (default 8monkey/hebo-platform:latest),
-# which replaces any published image of that name in your local Docker store.
-# Set HEBO_IMAGE in .env to tag it separately or to push to your own registry.
+# The result takes over the HEBO_IMAGE tag locally; set HEBO_IMAGE in .env to
+# keep it separate from the published image.
 
 services:
   hebo:

--- a/infra/self-hosted/docker-compose.build.yaml
+++ b/infra/self-hosted/docker-compose.build.yaml
@@ -1,0 +1,28 @@
+# Hebo self-hosted — build the image locally instead of pulling it.
+#
+# Needed when the console is served from a custom domain. The console is a
+# static SPA whose API/Auth/Gateway URLs are compiled into the bundle by Vite
+# at build time, so the published image cannot know them — it always falls back
+# to localhost. Set the VITE_* variables in .env and build your own image.
+#
+# Requires a full checkout of the repository: the build context is the repo
+# root, not this directory.
+#
+# Usage:
+#   docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
+#
+# The result is tagged with HEBO_IMAGE (default 8monkey/hebo-platform:latest),
+# which replaces any published image of that name in your local Docker store.
+# Set HEBO_IMAGE in .env to tag it separately or to push to your own registry.
+
+services:
+  hebo:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile
+      args:
+        NODE_ENV: production
+        VITE_API_URL: ${VITE_API_URL:-}
+        VITE_AUTH_URL: ${VITE_AUTH_URL:-}
+        VITE_GATEWAY_URL: ${VITE_GATEWAY_URL:-}
+        VITE_MAGICLINK_AUTH: ${VITE_MAGICLINK_AUTH:-}

--- a/infra/self-hosted/docker-compose.yaml
+++ b/infra/self-hosted/docker-compose.yaml
@@ -6,10 +6,13 @@
 #
 # Usage:
 #   docker compose up -d
+#
+# Serving the console from a custom domain requires building your own image —
+# see docker-compose.build.yaml.
 
 services:
   hebo:
-    image: 8monkey/hebo-platform:latest
+    image: ${HEBO_IMAGE:-8monkey/hebo-platform:latest}
     restart: unless-stopped
     ports:
       - "127.0.0.1:8520:8520"

--- a/infra/self-hosted/docker-compose.yaml
+++ b/infra/self-hosted/docker-compose.yaml
@@ -7,8 +7,7 @@
 # Usage:
 #   docker compose up -d
 #
-# Serving the console from a custom domain requires building your own image —
-# see docker-compose.build.yaml.
+# Custom domains require building your own image — see docker-compose.build.yaml.
 
 services:
   hebo:


### PR DESCRIPTION
Closes #477

## Problem

The console is a static SPA, so `VITE_API_URL` / `VITE_AUTH_URL` / `VITE_GATEWAY_URL` are compiled into the bundle by Vite at build time (`apps/console/app/lib/env.ts`). `infra/docker/Dockerfile` passed none of them, so the published image always fell back to `localhost:852x` and self-hosted deployments behind a custom domain pointed the console at the user's own machine.

## Approach

Option 1 from the issue — bake the URLs at build time.

- `infra/docker/Dockerfile` accepts the four `VITE_*` values as build args, declared **after** `bun install` so changing a domain reuses the dependency layer instead of reinstalling.
- Unset args stay empty and `env.ts` keeps its `||` fallback, so the published image is byte-for-byte equivalent in behaviour to today.
- `infra/self-hosted/docker-compose.build.yaml` (new) is an opt-in override that builds locally with those args from `.env`. Kept separate so the default `docker compose up -d` still pulls the prebuilt image and the README quickstart doesn't silently become a from-source build.
- `HEBO_IMAGE` makes the image tag overridable, so a locally built image needn't clobber the official `:latest` tag.

## Verification

Two real image builds of the `builder` stage:

| Build | `api/auth/gateway.example.com` in bundle | `localhost:8521/2/3` in bundle |
| --- | --- | --- |
| With build args | 1 / 1 / 1 | 0 / 0 / 0 |
| No build args (published-image path) | — | 1 / 1 / 1 |

URLs land in `build/client/assets/env-*.js`; Vite dead-code-eliminates the localhost fallbacks when a value is supplied. Merged compose config verified to resolve the build context to the repo root, interpolate all four args from `.env`, and apply the `HEBO_IMAGE` override.

## Note on scope

Baking URLs means anyone on a custom domain must build their own image rather than pull `8monkey/hebo-platform` — a known tradeoff of Option 1, called out in the issue and accepted.

Setting the `VITE_*` values alone is also not sufficient for a working custom-domain deployment: `BASE_URL` drives CORS, the better-auth base URL, trusted origins and the session cookie domain, and the self-hosted compose file sets none of it. This PR **documents** `BASE_URL` / `AUTH_URL` / `NODE_ENV` in the custom-domain instructions but changes no server-side behaviour. Worth separate issues:

- With `BASE_URL` unset, `packages/shared-api/lib/cors.ts:5` accepts **every** origin with `credentials: true`, and `apps/auth/src/better-auth.ts:88` sets `trustedOrigins: ["*"]` — wide open by default for a publicly exposed self-hosted deploy.
- `trustedOrigins` is `https://*.${ROOT_DOMAIN}` (subdomains only) while CORS also allows the apex, so a console on the apex domain passes CORS then fails `callbackURL` validation.
- `apps/mcp/src/index.ts` has no CORS and no auth middleware, and compose exposes port 8524.
- `VITE_MAGICLINK_AUTH` is baked while the auth server gates `emailAndPassword` on SMTP at runtime, so the two can disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom domains, HTTPS, OAuth callbacks, cookies, CORS, and OpenAPI URLs in self-hosted deployments.
  * Documented frontend build-time configuration and deployment environment variables.

* **New Features**
  * Added support for building custom self-hosted images with configurable API, authentication, gateway, and magic-link URLs.
  * Made the self-hosted image configurable, with the standard image used by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->