### PR TITLE
fix(api): scope BYOK provider credential lookup to the organization

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,6 +13,21 @@ jobs:
     name: Run Quality Checks
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:17.6
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: hebo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d hebo"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,6 +45,11 @@ jobs:
 
       - name: Run typecheck
         run: bun run typecheck
+
+      - name: Generate Prisma client and apply migrations
+        run: |
+          bun run -F @hebo/api db generate
+          bun run -F @hebo/api db:deploy
 
       - name: Run tests
         run: bun run test

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate Prisma client and apply migrations
         run: |
           bun run -F @hebo/api db generate
-          bun run -F @hebo/api db:deploy
+          bun run -F @hebo/api db migrate deploy
 
       - name: Run tests
         run: bun run test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,6 @@
     "build": "bun build src/index.ts --minify-whitespace --minify-syntax --keep-names --target=bun --outdir dist $([ \"$NODE_ENV\" = production ] && echo '--production')",
     "clean": "git clean -fdx -e '.env*' .",
     "db": "prisma",
-    "db:deploy": "bun run db migrate deploy",
     "db:migrate": "bun run db migrate dev",
     "db:reset": "bun run db migrate reset --force",
     "predev": "test -d src/generated || bun run db generate",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "build": "bun build src/index.ts --minify-whitespace --minify-syntax --keep-names --target=bun --outdir dist $([ \"$NODE_ENV\" = production ] && echo '--production')",
     "clean": "git clean -fdx -e '.env*' .",
     "db": "prisma",
+    "db:deploy": "bun run db migrate deploy",
     "db:migrate": "bun run db migrate dev",
     "db:reset": "bun run db migrate reset --force",
     "predev": "test -d src/generated || bun run db generate",

--- a/apps/api/src/db/prisma.test.ts
+++ b/apps/api/src/db/prisma.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { createPrismaClient } from "./prisma";
+
+const USER_A = "user-a";
+const USER_B = "user-b";
+
+const identityFederationConfig = {
+  authMode: "identity-federation",
+  serviceAccountEmail: "sample-sa@sample-project.iam.gserviceaccount.com",
+  audience: "//iam.googleapis.com/projects/000000/locations/global/workloadIdentityPools/sample",
+  location: "us-central1",
+  project: "sample-project",
+} as const;
+
+const serviceAccountConfig = {
+  authMode: "service-account",
+  clientEmail: "sample-sa@sample-project.iam.gserviceaccount.com",
+  privateKey: "-----BEGIN PRIVATE KEY-----\nsample-private-key\n-----END PRIVATE KEY-----\n",
+  location: "us-central1",
+  project: "sample-project",
+} as const;
+
+const createdOrganizationIds: string[] = [];
+
+const newOrganizationId = () => {
+  const organizationId = `org-prisma-test-${crypto.randomUUID()}`;
+  createdOrganizationIds.push(organizationId);
+  return organizationId;
+};
+
+// Raw SQL, because the query extension forces `deleted_at: null` onto every
+// `deleteMany`, which would leave soft-deleted rows behind.
+afterEach(async () => {
+  await Promise.all(
+    createdOrganizationIds.splice(0).map((organizationId) => {
+      const client = createPrismaClient(organizationId, USER_A);
+      return client.$executeRaw`delete from api.provider_configs where organization_id = ${organizationId}`;
+    }),
+  );
+});
+
+describe("provider_configs.getUnredacted", () => {
+  it("returns an identity-federation config saved by another member of the organization", async () => {
+    const organizationId = newOrganizationId();
+    await createPrismaClient(organizationId, USER_A).provider_configs.create({
+      data: { provider_slug: "vertex", value: identityFederationConfig },
+    });
+
+    const config = await createPrismaClient(organizationId, USER_B).provider_configs.getUnredacted(
+      "vertex",
+    );
+
+    expect(config).not.toBeNull();
+    expect(config?.value).toEqual(identityFederationConfig);
+    expect(config?.created_by).toBe(USER_A);
+    expect(config?.organization_id).toBe(organizationId);
+  });
+
+  it("returns the real private key of a service-account config saved by another member", async () => {
+    const organizationId = newOrganizationId();
+    await createPrismaClient(organizationId, USER_A).provider_configs.create({
+      data: { provider_slug: "vertex", value: serviceAccountConfig },
+    });
+
+    const config = await createPrismaClient(organizationId, USER_B).provider_configs.getUnredacted(
+      "vertex",
+    );
+
+    expect(config?.value).toEqual(serviceAccountConfig);
+    expect(config?.value).toHaveProperty("privateKey", serviceAccountConfig.privateKey);
+  });
+
+  it("does not return a config belonging to another organization", async () => {
+    const organizationId = newOrganizationId();
+    const otherOrganizationId = newOrganizationId();
+    await createPrismaClient(organizationId, USER_A).provider_configs.create({
+      data: { provider_slug: "vertex", value: serviceAccountConfig },
+    });
+
+    const config = await createPrismaClient(
+      otherOrganizationId,
+      USER_B,
+    ).provider_configs.getUnredacted("vertex");
+
+    expect(config).toBeNull();
+  });
+
+  it("does not return a soft-deleted config", async () => {
+    const organizationId = newOrganizationId();
+    const clientA = createPrismaClient(organizationId, USER_A);
+    const created = await clientA.provider_configs.create({
+      data: { provider_slug: "vertex", value: serviceAccountConfig },
+    });
+    await clientA.provider_configs.softDelete({ id: created.id });
+
+    const config = await clientA.provider_configs.getUnredacted("vertex");
+
+    expect(config).toBeNull();
+  });
+});
+
+describe("provider_configs redaction", () => {
+  it("masks the private key when read through the extended client", async () => {
+    const organizationId = newOrganizationId();
+    await createPrismaClient(organizationId, USER_A).provider_configs.create({
+      data: { provider_slug: "vertex", value: serviceAccountConfig },
+    });
+
+    const config = await createPrismaClient(organizationId, USER_B).provider_configs.findFirst({
+      where: { provider_slug: "vertex" },
+    });
+
+    expect(config?.value).toEqual({ ...serviceAccountConfig, privateKey: "***" });
+  });
+});

--- a/apps/api/src/db/prisma.ts
+++ b/apps/api/src/db/prisma.ts
@@ -97,7 +97,6 @@ export const createPrismaClient = (organizationId: string, userId: string) => {
           return prisma.provider_configs.findFirst({
             where: {
               provider_slug: slug,
-              created_by: userId,
               deleted_at: DB_NULL,
               organization_id: organizationId,
             },


### PR DESCRIPTION
## Summary

- Remove the `created_by: userId` filter from `provider_configs.getUnredacted`, so BYOK credentials saved by one organization member resolve for every member's API key
- Add `apps/api/src/db/prisma.test.ts`, the first database-backed test in the repo, covering the cross-member lookup, redaction, tenant isolation, and soft deletes
- Add a `postgres` service and a Prisma migrate step to the quality workflow so database-backed tests run in CI

Closes #483

## Root cause

`provider_configs` is an organization-level resource. The write path, the console list, and the gateway's provider cache are all organization-scoped, but the gateway's credential lookup filtered on `created_by` as well:

```ts
// apps/api/src/db/prisma.ts
getUnredacted(slug: string) {
  return prisma.provider_configs.findFirst({
    where: {
      provider_slug: slug,
      created_by: userId,        // audit metadata used as an authorization filter
      deleted_at: DB_NULL,
      organization_id: organizationId,
    },
  });
}
```

At chat time `userId` is the API key's creator (`packages/shared-api/middlewares/auth.ts`, `result.key.metadata.createdByUserId`), which is not necessarily the member who saved the credentials. When it differs, `findFirst` returns `null`. `resolveCustomProvider` cannot distinguish "not configured" from "configured by someone else" — both are `null` — so it falls through and `selectProviderWithByokFallback` throws `402 BYOK_REQUIRED`.

`PUT /providers/:slug/config` soft-deletes the organization's existing row and inserts a new one owned by whoever saved it, so there is only ever one live row per provider. That is why re-saving as the organization owner appeared to fix it: it moved ownership back to the user whose API key was being used.

## Why it looked intermittent

The provider cache in `apps/gateway/src/lib/hooks.ts` is keyed by organization, not by user:

```ts
const configCacheKey = `${organizationId}:${customProviderSlug}:${modelId}`;
```

Whoever made the first request decided the outcome for the whole organization for the next 5 minutes. Driving `selectProviderWithByokFallback` with real Prisma clients, credentials saved by `user-admin` in both runs:

```
--- admin first ---
  request 1 by user-admin: provider resolved (request succeeds)
  request 2 by user-owner: provider resolved (request succeeds)

--- owner first ---
  request 1 by user-owner: error (402, request fails)
  request 2 by user-admin: error (402, request fails)
```

If the credential owner went first everyone worked. If anyone else went first, `"default"` was cached and even the member who saved the credentials got a 402. This is the "only succeeds for some users" symptom. The fix makes the lookup agree with the cache key.

## The fix

```diff
           return prisma.provider_configs.findFirst({
             where: {
               provider_slug: slug,
-              created_by: userId,
               deleted_at: DB_NULL,
               organization_id: organizationId,
             },
```

`created_by` remains recorded on write as audit metadata; it no longer gates reads. `organization_id` and `deleted_at` still scope the query, which matters because `getUnredacted` deliberately uses the base client to bypass the redaction result extension and therefore does not inherit the tenant filters applied to other queries.

No migration or backfill is needed. Existing rows are already correct.

For Vertex `identity-federation` the old filter protected nothing: none of its fields are marked `redact`, so any member could already read the complete, usable config through `GET /providers`.

## Test plan

- [x] `apps/api/src/db/prisma.test.ts` against local Postgres — 5 pass, 0 fail
- [x] Verified the test guards the regression: re-adding `created_by: userId` fails the two cross-member cases
      ```
      (fail) returns an identity-federation config saved by another member of the organization
      (fail) returns the real private key of a service-account config saved by another member
      (pass) does not return a config belonging to another organization
      (pass) does not return a soft-deleted config
      (pass) masks the private key when read through the extended client
       3 pass, 2 fail
      ```
- [x] Confirmed `privateKey` is still masked as `***` through the ordinary client and returned in full through `getUnredacted`
- [x] Confirmed cross-organization lookups still return nothing
- [x] Reproduced the original failure and confirmed the fix end to end through `selectProviderWithByokFallback` with real Prisma clients, for both Vertex auth modes and both request orderings
- [x] `api.provider_configs` row count unchanged before and after test runs, including failing runs
- [x] `bun run lint`, `bun run -F @hebo/api typecheck`, `bun run test` (0 fail across api, shared-api, gateway)
- [ ] Not verified: the new workflow steps running on a GitHub Actions runner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider configuration retrieval now correctly supports organization-scoped access without unnecessarily restricting results to the creator.
  * Soft-deleted configurations remain excluded.
  * Sensitive credentials continue to be protected, with private keys redacted where appropriate.

* **Tests**
  * Added coverage for provider configuration access, credential handling, organization isolation, and soft deletion.
  * Automated testing now runs against a provisioned PostgreSQL database with migrations applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->