### PR TITLE
upgrade to hebo-gateway 0.12.2

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -36,7 +36,7 @@
     "@elysia/cors": "catalog:",
     "@elysia/openapi": "catalog:",
     "@elysia/opentelemetry": "catalog:",
-    "@hebo-ai/gateway": "0.12.0-rc0",
+    "@hebo-ai/gateway": "0.12.1",
     "@hebo/api": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -36,7 +36,7 @@
     "@elysia/cors": "catalog:",
     "@elysia/openapi": "catalog:",
     "@elysia/opentelemetry": "catalog:",
-    "@hebo-ai/gateway": "0.12.1",
+    "@hebo-ai/gateway": "0.12.2",
     "@hebo/api": "workspace:*",
     "@hebo/shared-api": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/apps/gateway/src/lib/provider.test.ts
+++ b/apps/gateway/src/lib/provider.test.ts
@@ -59,6 +59,28 @@ describe("createProvider", () => {
       expect(provider).toBeDefined();
     });
 
+    it("serves GPT-5.x from mantle and everything else from converse with an IAM role", () => {
+      const provider = createProvider("bedrock", {
+        authMode: "iam-role",
+        bedrockRoleArn: "arn:aws:iam::123456789012:role/test-role",
+        region: "us-east-1",
+      });
+      expect(provider.languageModel("openai/gpt-5.6-sol").provider).toBe(
+        "bedrock-mantle.responses",
+      );
+      expect(provider.languageModel("anthropic/claude-opus-5").provider).toBe("amazon-bedrock");
+    });
+
+    it("serves GPT-5.x from mantle with access-key credentials", () => {
+      const provider = createProvider("bedrock", {
+        authMode: "access-key",
+        accessKeyId: "AKIA1234567890ABCDEF",
+        secretAccessKey: "secretkey123",
+        region: "us-east-1",
+      });
+      expect(provider.languageModel("openai/gpt-5.5").provider).toBe("bedrock-mantle.responses");
+    });
+
     it("returns a provider when authMode is invalid (fallback)", () => {
       const provider = createProvider("bedrock", {
         authMode: "api-key",

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -141,30 +141,26 @@ export function createProvider(slug: ProviderSlug, config: unknown): ProviderV4 
       switch (bedrockConfig.authMode) {
         case "access-key": {
           const { accessKeyId, secretAccessKey, region } = bedrockConfig;
-          return withCanonicalIdsForBedrock(
-            createAmazonBedrock({
-              region,
-              credentialProvider: () => Promise.resolve({ accessKeyId, secretAccessKey }),
-            }),
-          );
+          const credentialProvider = () => Promise.resolve({ accessKeyId, secretAccessKey });
+          // Mantle serves the GPT-5.x models and signs for `bedrock-mantle` instead of
+          // `bedrock`, so it needs its own copy of the credentials.
+          return withCanonicalIdsForBedrock(createAmazonBedrock({ region, credentialProvider }), {
+            mantle: { credentialProvider },
+          });
         }
         case "iam-role": {
           const { bedrockRoleArn, region } = bedrockConfig;
-          return withCanonicalIdsForBedrock(
-            createAmazonBedrock({
-              region,
-              credentialProvider: fromTemporaryCredentials({
-                params: { RoleArn: bedrockRoleArn },
-                masterCredentials: fromContainerMetadata(),
-                clientConfig: { region },
-              }),
-            }),
-            {
-              inferenceProfile: {
-                arn: { accountId: bedrockRoleArn?.split(":")[4], region },
-              },
+          const credentialProvider = fromTemporaryCredentials({
+            params: { RoleArn: bedrockRoleArn },
+            masterCredentials: fromContainerMetadata(),
+            clientConfig: { region },
+          });
+          return withCanonicalIdsForBedrock(createAmazonBedrock({ region, credentialProvider }), {
+            inferenceProfile: {
+              arn: { accountId: bedrockRoleArn?.split(":")[4], region },
             },
-          );
+            mantle: { credentialProvider },
+          });
         }
         default:
           return withCanonicalIdsForBedrock(createAmazonBedrock());

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
         "@elysia/cors": "catalog:",
         "@elysia/openapi": "catalog:",
         "@elysia/opentelemetry": "catalog:",
-        "@hebo-ai/gateway": "0.12.1",
+        "@hebo-ai/gateway": "0.12.2",
         "@hebo/api": "workspace:*",
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
@@ -629,7 +629,7 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.12.1", "", { "dependencies": { "@ai-sdk/provider": "^4.0.5", "ai": "^7.0.52", "lru-cache": "^11.5.2", "uuid": "^14.0.1", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/alibaba": "^2.0.25", "@ai-sdk/amazon-bedrock": "^5.0.43", "@ai-sdk/anthropic": "^4.0.30", "@ai-sdk/cohere": "^4.0.21", "@ai-sdk/deepinfra": "^3.0.23", "@ai-sdk/deepseek": "^3.0.22", "@ai-sdk/fireworks": "^3.0.25", "@ai-sdk/google-vertex": "^5.0.41", "@ai-sdk/groq": "^4.0.22", "@ai-sdk/moonshotai": "^3.0.26", "@ai-sdk/openai": "^4.0.30", "@ai-sdk/togetherai": "^3.0.24", "@ai-sdk/xai": "^4.0.28", "@libsql/client": "^0.17.3", "@opentelemetry/api": "^1.9.1", "better-sqlite3": "^12.9.0", "mysql2": "^3.22.3", "pg": "^8.20.0", "postgres": "^3.4.9", "typescript": ">=5.9.3", "voyage-ai-provider": "^4.0.0", "zhipu-ai-provider": "^0.4.0" }, "optionalPeers": ["@ai-sdk/alibaba", "@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/deepinfra", "@ai-sdk/deepseek", "@ai-sdk/fireworks", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/moonshotai", "@ai-sdk/openai", "@ai-sdk/togetherai", "@ai-sdk/xai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider", "zhipu-ai-provider"] }, "sha512-7dN7mYc+p5AITROZrkIxKr2GyUF4SLcCETE7OYtfykTZqQjb2KOr4ZNYvLDgUycEuTp7SRHK8C+NbHYKDjlVBA=="],
+    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.12.2", "", { "dependencies": { "@ai-sdk/provider": "^4.0.5", "ai": "^7.0.52", "lru-cache": "^11.5.2", "uuid": "^14.0.1", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/alibaba": "^2.0.25", "@ai-sdk/amazon-bedrock": "^5.0.43", "@ai-sdk/anthropic": "^4.0.30", "@ai-sdk/cohere": "^4.0.21", "@ai-sdk/deepinfra": "^3.0.23", "@ai-sdk/deepseek": "^3.0.22", "@ai-sdk/fireworks": "^3.0.25", "@ai-sdk/google-vertex": "^5.0.41", "@ai-sdk/groq": "^4.0.22", "@ai-sdk/moonshotai": "^3.0.26", "@ai-sdk/openai": "^4.0.30", "@ai-sdk/togetherai": "^3.0.24", "@ai-sdk/xai": "^4.0.28", "@libsql/client": "^0.17.3", "@opentelemetry/api": "^1.9.1", "better-sqlite3": "^12.9.0", "mysql2": "^3.22.3", "pg": "^8.20.0", "postgres": "^3.4.9", "typescript": ">=5.9.3", "voyage-ai-provider": "^4.0.0", "zhipu-ai-provider": "^0.4.0" }, "optionalPeers": ["@ai-sdk/alibaba", "@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/deepinfra", "@ai-sdk/deepseek", "@ai-sdk/fireworks", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/moonshotai", "@ai-sdk/openai", "@ai-sdk/togetherai", "@ai-sdk/xai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider", "zhipu-ai-provider"] }, "sha512-StekTsNmGuGBubfJvUs4b4Vd9rWtS39WY7eAHs3xbfY2qL1jR5GXYQC6z4yxA4N1ViceLAjnjB+CoEwnd+AzxQ=="],
 
     "@hebo/aikit-ui": ["@hebo/aikit-ui@workspace:packages/aikit-ui"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -136,7 +136,7 @@
         "@elysia/cors": "catalog:",
         "@elysia/openapi": "catalog:",
         "@elysia/opentelemetry": "catalog:",
-        "@hebo-ai/gateway": "0.12.0-rc0",
+        "@hebo-ai/gateway": "0.12.1",
         "@hebo/api": "workspace:*",
         "@hebo/shared-api": "workspace:*",
         "@opentelemetry/api": "catalog:",
@@ -629,7 +629,7 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.12.0-rc0", "", { "dependencies": { "@ai-sdk/provider": "^4.0.5", "ai": "^7.0.52", "lru-cache": "^11.5.2", "uuid": "^14.0.1", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/alibaba": "^2.0.25", "@ai-sdk/amazon-bedrock": "^5.0.43", "@ai-sdk/anthropic": "^4.0.30", "@ai-sdk/cohere": "^4.0.21", "@ai-sdk/deepinfra": "^3.0.23", "@ai-sdk/deepseek": "^3.0.22", "@ai-sdk/fireworks": "^3.0.25", "@ai-sdk/google-vertex": "^5.0.41", "@ai-sdk/groq": "^4.0.22", "@ai-sdk/moonshotai": "^3.0.26", "@ai-sdk/openai": "^4.0.30", "@ai-sdk/togetherai": "^3.0.24", "@ai-sdk/xai": "^4.0.28", "@libsql/client": "^0.17.3", "@opentelemetry/api": "^1.9.1", "better-sqlite3": "^12.9.0", "mysql2": "^3.22.3", "pg": "^8.20.0", "postgres": "^3.4.9", "typescript": ">=5.9.3", "voyage-ai-provider": "^4.0.0", "zhipu-ai-provider": "^0.4.0" }, "optionalPeers": ["@ai-sdk/alibaba", "@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/deepinfra", "@ai-sdk/deepseek", "@ai-sdk/fireworks", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/moonshotai", "@ai-sdk/openai", "@ai-sdk/togetherai", "@ai-sdk/xai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider", "zhipu-ai-provider"] }, "sha512-PLqPuWklzQx+ACAaahhwSRgX+4d+yX5mLSLVHZz/+icM12f5rBs77pvrDF1s130wFcPQAH/vZdW57LORXOIGNg=="],
+    "@hebo-ai/gateway": ["@hebo-ai/gateway@0.12.1", "", { "dependencies": { "@ai-sdk/provider": "^4.0.5", "ai": "^7.0.52", "lru-cache": "^11.5.2", "uuid": "^14.0.1", "zod": "^4.3.6" }, "peerDependencies": { "@ai-sdk/alibaba": "^2.0.25", "@ai-sdk/amazon-bedrock": "^5.0.43", "@ai-sdk/anthropic": "^4.0.30", "@ai-sdk/cohere": "^4.0.21", "@ai-sdk/deepinfra": "^3.0.23", "@ai-sdk/deepseek": "^3.0.22", "@ai-sdk/fireworks": "^3.0.25", "@ai-sdk/google-vertex": "^5.0.41", "@ai-sdk/groq": "^4.0.22", "@ai-sdk/moonshotai": "^3.0.26", "@ai-sdk/openai": "^4.0.30", "@ai-sdk/togetherai": "^3.0.24", "@ai-sdk/xai": "^4.0.28", "@libsql/client": "^0.17.3", "@opentelemetry/api": "^1.9.1", "better-sqlite3": "^12.9.0", "mysql2": "^3.22.3", "pg": "^8.20.0", "postgres": "^3.4.9", "typescript": ">=5.9.3", "voyage-ai-provider": "^4.0.0", "zhipu-ai-provider": "^0.4.0" }, "optionalPeers": ["@ai-sdk/alibaba", "@ai-sdk/amazon-bedrock", "@ai-sdk/anthropic", "@ai-sdk/cohere", "@ai-sdk/deepinfra", "@ai-sdk/deepseek", "@ai-sdk/fireworks", "@ai-sdk/google-vertex", "@ai-sdk/groq", "@ai-sdk/moonshotai", "@ai-sdk/openai", "@ai-sdk/togetherai", "@ai-sdk/xai", "@libsql/client", "better-sqlite3", "mysql2", "pg", "postgres", "voyage-ai-provider", "zhipu-ai-provider"] }, "sha512-7dN7mYc+p5AITROZrkIxKr2GyUF4SLcCETE7OYtfykTZqQjb2KOr4ZNYvLDgUycEuTp7SRHK8C+NbHYKDjlVBA=="],
 
     "@hebo/aikit-ui": ["@hebo/aikit-ui@workspace:packages/aikit-ui"],
 


### PR DESCRIPTION
Upgrades `@hebo-ai/gateway` from `0.12.0-rc0` to `0.12.1`, which adds the GPT-5.6 models (`sol`, `terra`, `luna`), `grok-4.5`/`grok-4.6`, and nests Bedrock's OpenAI-compatible Mantle endpoint for the GPT-5.x models.

Mantle inherits the wrapped Bedrock provider's region and headers but **not** its credentials (its SigV4 signer is bound to `bedrock`, while Mantle requires `bedrock-mantle`). Without configuration it would fall back to ambient AWS env credentials — on ECS that is the task role, not the assumed `BEDROCK_ROLE_ARN` cross-account role. The credential provider is therefore hoisted and passed to both providers for the `iam-role` and `access-key` auth modes.

### Verification

- `openai/gpt-5.6-sol` resolves to `bedrock-mantle.responses` / `openai.gpt-5.6-sol`; `anthropic/claude-opus-5` still resolves to `amazon-bedrock` with the inference-profile prefix.
- Against a stubbed `fetch`, the Mantle request is signed with the configured credentials in the `bedrock-mantle` scope; in `iam-role` mode it goes through `fromTemporaryCredentials` rather than ambient credentials.
- Two unit tests added to `apps/gateway/src/lib/provider.test.ts`.

### Tests

`bun run -F @hebo/gateway test` (36 pass), `bun run -F @hebo/shared-api test` (3 pass), `bun run -F @hebo/gateway typecheck`, `bun run lint`, `bun run lint:deps` — all clean. `@hebo/api` tests need a local Postgres and were not run.

### Follow-ups

- Mantle is available in fewer regions than `bedrock-runtime`; its region is inherited from `BEDROCK_REGION`. If that region has no Mantle endpoint, a `BEDROCK_MANTLE_REGION` secret and a `mantle.region` override are needed.
- Confirm the cross-account role policy in `infra/provider/configure-bedrock-access.sh` covers Mantle invocations with a real GPT-5.6 call.

Closes #486

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5.x models through the Mantle responses provider when using Amazon Bedrock.
  * Supports both IAM-role and access-key authentication for GPT-5.x model requests.
* **Bug Fixes**
  * Preserved existing Amazon Bedrock Converse behavior for non-GPT-5.x models.
  * Improved handling of inference-profile configurations for IAM-authenticated requests.
* **Tests**
  * Added coverage for GPT-5.x provider selection and both supported authentication methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->